### PR TITLE
Fix typings to work with webpack

### DIFF
--- a/oidc-client.d.ts
+++ b/oidc-client.d.ts
@@ -1,6 +1,5 @@
-declare module "oidc-client" {
-    export = Oidc;
-}
+export = Oidc;
+
 declare namespace Oidc {
 	interface Logger  {
 		error(message?: any, ...optionalParams: any[]): void;


### PR DESCRIPTION
Since the typings were added to the package.json (#85), they no longer work with Webpack.

The solution is to remove the module declaration.
