### PR TITLE
Support changing the store in WebStorageStateStore by adding proper TypeScript declarations

### DIFF
--- a/oidc-client.d.ts
+++ b/oidc-client.d.ts
@@ -135,6 +135,7 @@ declare namespace Oidc {
 
         signoutRedirect(args?: any): Promise<any>;
         signoutRedirectCallback(url?: string): Promise<any>;
+        signoutPopup(args?: any): Promise<any>;
 
         querySessionStatus(args?: any): Promise<any>;
 
@@ -168,7 +169,15 @@ declare namespace Oidc {
         iframeNavigator?: any;
         userStore?: any;
     }
-    interface WebStorageStateStore {
+
+    interface WebStorageStateStoreSettings {
+        prefix?: string;
+        store?: any;
+    }
+
+    class WebStorageStateStore {
+        constructor(settings: WebStorageStateStoreSettings);
+
         set(key: string, value: any): Promise<void>;
 
         get(key: string): Promise<any>;


### PR DESCRIPTION
Pull request for #159.

WebStorageStateStore  can be configured to use a different storage than the default. UserManagerSettings is using this to make use of Global.sessionStorage. This default of UserManagerSettings can also be changed in using the UserManagerSettings class.

However, with TypeScript this cannot be done because of the following three reasons:
- WebStorageStateStore is defined as an interface and can therefore not be instantiated. I.e., the following does not work: `userStore: new Oidc.WebStorageStateStore()`
- The typescript definition of WebStorageStateStore doesn't have a constructor defined, so the compiler complains when trying to pass an argument in the constructor: 
- There is no TypeScript definition for the options that are accepted by WebStorageStateStore.

In this pull request I therefore 1) changed the interface definition into a class definition; 2) added a constructor; 3) added `WebStorageStateStoreSettings` . With these changes the store can be configured in UserManagerSettings as follows:

``` javascript
var settings: Oidc.UserManagerSettings = {
                // other settings
                userStore: new Oidc.WebStorageStateStore({ store: localStorage })
            }
```
