### PR TITLE
Fixing JoseUtil aud validation to be more in line with spec

### DIFF
--- a/src/JoseUtil.js
+++ b/src/JoseUtil.js
@@ -78,7 +78,7 @@ export default class JoseUtil {
             return Promise.reject(new Error("Invalid issuer in token: " + payload.iss));
         }
 
-        if (payload.aud !== audience) {
+        if (payload.aud !== audience && (Array.isArray(payload.aud) && payload.aud.indexOf(audience) === -1)) {
             Log.error("Invalid audience in token", payload.aud);
             return Promise.reject(new Error("Invalid audience in token: " + payload.aud));
         }


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7519#section-4.1.3 says that aud, in general, will be an array, but a single value is allowed to be just a string, but they may not necessarily be the case.
