### PR TITLE
Moved ES2015 support to Babel transform-runtime.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
     "presets": ["es2015"],
     "plugins": [
         "babel-plugin-add-module-exports", 
-        ["transform-es2015-classes", {
+        ["transform-runtime", {
             "loose": true
         }]
     ]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,11 @@
 var gulp = require('gulp');
+var babel = require('gulp-babel');
 var webpackStream = require('webpack-stream');
 var webpack = require('webpack');
 var createWebpackConfig = require('./webpack.base');
 
 // entry points for both configs
 var npmEntry = './index.js';
-var classicEntry = ['babel-polyfill', npmEntry];
 
 // uglify plugin for minification
 var uglifyPlugins =  [
@@ -50,8 +50,8 @@ gulp.task('build-lib-min', function() {
 // classic build with sourcemaps
 gulp.task('build-dist-sourcemap', function() {
   // run webpack
-  gulp.src('index.js').pipe(webpackStream(createWebpackConfig({
-    entry: classicEntry,
+  gulp.src('index.js').pipe(babel()).pipe(webpackStream(createWebpackConfig({
+    entry: npmEntry,
     output: {
         filename: 'oidc-client.js',
         libraryTarget: 'var',
@@ -66,8 +66,8 @@ gulp.task('build-dist-sourcemap', function() {
 // classic build without sourcemaps & minified
 gulp.task('build-dist-min', function() {
   // run webpack
-  gulp.src('index.js').pipe(webpackStream(createWebpackConfig({
-    entry: classicEntry,
+  gulp.src('index.js').pipe(babel()).pipe(webpackStream(createWebpackConfig({
+    entry: npmEntry,
     output: {
         filename: 'oidc-client.min.js',
         libraryTarget: 'var',

--- a/package.json
+++ b/package.json
@@ -33,21 +33,21 @@
     "babel-loader": "^6.2.4",
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-plugin-transform-es2015-classes": "^6.7.7",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
     "chai": "^3.5.0",
     "express": "^4.13.4",
     "gulp": "^3.9.1",
+    "gulp-babel": "^6.1.2",
     "mocha": "^2.4.5",
     "open": "0.0.5",
     "webpack": "^1.12.14",
     "webpack-stream": "^3.2.0"
   },
   "dependencies": {
+    "babel-runtime": "^6.18.0",
     "jsrsasign": "^5.0.7"
-  },
-  "peerDependencies": {
-    "babel-polyfill": ">=6.7.4"
   },
   "typings": "oidc-client.d.ts"
 }


### PR DESCRIPTION
Fix for issue #174
Modified build configuration to replace Babel-Polyfill with the Babel transform-runtime plugin to provide polyfills without polluting the global namespace.
