### PR TITLE
Change time of accessTokenExpiringNotificationTime setting to number

### DIFF
--- a/oidc-client.d.ts
+++ b/oidc-client.d.ts
@@ -167,7 +167,7 @@ declare namespace Oidc {
         monitorSession?: any;
         checkSessionInterval?: any;
         revokeAccessTokenOnSignout?: any;
-        accessTokenExpiringNotificationTime?: string;
+        accessTokenExpiringNotificationTime?: number;
         redirectNavigator?: any;
         popupNavigator?: any;
         iframeNavigator?: any;


### PR DESCRIPTION
If I look at [code using the accessTokenExpiringNotificationTime field](https://github.com/IdentityModel/oidc-client-js/blob/8adf3602600b76689b8428ea96ee703fe7c313ea/src/AccessTokenEvents.js#L34), it appears to be used as a number.