### PR TITLE
updated signing keys type to array

### DIFF
--- a/oidc-client.d.ts
+++ b/oidc-client.d.ts
@@ -96,7 +96,7 @@ declare namespace Oidc {
         authority?: string;
         metadataUrl?: string;
         metadata?: any;
-        signingKeys?: string;
+        signingKeys?: any[];
         client_id?: string;
         response_type?: string;
         scope?: string;


### PR DESCRIPTION
The signing keys are an array of objects containing the keys and not a string