### PR TITLE
Fix local storage access denied bug in ie11

### DIFF
--- a/src/Global.js
+++ b/src/Global.js
@@ -24,8 +24,17 @@ export default class Global {
         }
     }
     static get localStorage() {
+        let st = null;
+        //catch access denied errors in ie <= 11
+        try{
+          st = window.localStorage;
+        }
+        catch(ex){
+            //fallback to session storage
+          st = window.sessionStorage;
+        }
         if (!testing) {
-            return localStorage;
+          return st;
         }
     }
     static get sessionStorage() {


### PR DESCRIPTION
In IE11 or less, attempts to access local storage for a site that isn't in the trusted sites results in an access denied exception.

Changed the localstorage call to fall back to session storage in those cases.

I assume use of sessionStorage wouldn't cause any security risks - though it would make state storage more brittle (ie. not surviving when a tab is closed etc).