### PR TITLE
add .babelrc to .gitignore for React Native project compatibility

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 sample/
 test/
+.babelrc


### PR DESCRIPTION
This was the only change I needed in the end to get the project working with React Native. 

This seems to be the solution taken by packages wishing to support react native 
https://github.com/facebook/react-native/issues/4062
https://github.com/gaearon/redux-thunk/issues/43

