### PR TITLE
added support for extra/custom query params with test

### DIFF
--- a/src/OidcClient.js
+++ b/src/OidcClient.js
@@ -40,11 +40,11 @@ export default class OidcClient {
 
     createSigninRequest({
         response_type, scope, redirect_uri, 
-        // data was meant to be the place a caller could indiate the data to 
+        // data was meant to be the place a caller could indicate the data to
         // have round tripped, but people were getting confused, so i added state (since that matches the spec) 
         // and so now if data is not passed, but state is then state will be used
-        data, state,
-        prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values, resource, request, request_uri} = {},
+        data, state, prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values,
+        resource, request, request_uri, extraQueryParams } = {},
         stateStore
     ) {
         Log.debug("OidcClient.createSigninRequest");
@@ -61,6 +61,7 @@ export default class OidcClient {
         ui_locales = ui_locales || this._settings.ui_locales;
         acr_values = acr_values || this._settings.acr_values;
         resource = resource || this._settings.resource;
+        extraQueryParams = extraQueryParams || this._settings.extraQueryParams;
         
         let authority = this._settings.authority;
 
@@ -75,7 +76,8 @@ export default class OidcClient {
                 scope,
                 data: data || state,
                 authority,
-                prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values, resource, request, request_uri
+                prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values,
+                resource, request, request_uri, extraQueryParams,
             });
 
             var signinState = signinRequest.state;

--- a/src/OidcClientSettings.js
+++ b/src/OidcClientSettings.js
@@ -28,7 +28,9 @@ export default class OidcClientSettings {
         // other behavior
         stateStore = new WebStorageStateStore(),
         ResponseValidatorCtor = ResponseValidator,
-        MetadataServiceCtor = MetadataService
+        MetadataServiceCtor = MetadataService,
+        // extra query params
+        extraQueryParams = {}
     } = {}) {
 
         this._authority = authority;
@@ -58,6 +60,8 @@ export default class OidcClientSettings {
         this._stateStore = stateStore;
         this._validator = new ResponseValidatorCtor(this);
         this._metadataService = new MetadataServiceCtor(this);
+
+        this._extraQueryParams = typeof extraQueryParams === 'object' ? extraQueryParams : {};
     }
 
     // client config
@@ -178,5 +182,17 @@ export default class OidcClientSettings {
     }
     get metadataService() {
         return this._metadataService;
+    }
+
+    // extra query params
+    get extraQueryParams() {
+        return this._extraQueryParams;
+    }
+    set extraQueryParams(value) {
+        if (typeof value === 'object'){
+            this._extraQueryParams = value;
+        } else {
+            this._extraQueryParams = {};
+        }
     }
 }

--- a/src/SigninRequest.js
+++ b/src/SigninRequest.js
@@ -10,7 +10,8 @@ export default class SigninRequest {
         // mandatory
         url, client_id, redirect_uri, response_type, scope, authority,
         // optional
-        data, prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values, resource, request, request_uri
+        data, prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values, resource,
+        request, request_uri, extraQueryParams,
     }) {
         if (!url) {
             Log.error("No url passed to SigninRequest");
@@ -55,6 +56,10 @@ export default class SigninRequest {
             if (optional[key]) {
                 url = UrlUtility.addQueryParam(url, key, optional[key]);
             }
+        }
+
+        for(let key in extraQueryParams){
+            url = UrlUtility.addQueryParam(url, key, extraQueryParams[key])
         }
 
         this.url = url;

--- a/test/unit/OidcClientSettings.spec.js
+++ b/test/unit/OidcClientSettings.spec.js
@@ -392,4 +392,51 @@ describe("OidcClientSettings", function () {
         });
     });
 
+    describe("extraQueryParams", function() {
+
+        it("should use default value", function () {
+            let subject = new OidcClientSettings({
+                client_id: 'client'
+            });
+            subject.extraQueryParams.should.deep.equal({});
+        });
+
+        it("should return value from initial settings", function () {
+            let subject = new OidcClientSettings({
+                client_id: 'client',
+                extraQueryParams: {
+                    'hd': 'domain.com'
+                }
+            });
+            subject.extraQueryParams.should.deep.equal({ 'hd': 'domain.com' });
+        });
+
+        it("should not set value from initial settings if not object, but set default value ({})", function () {
+            let subject = new OidcClientSettings({
+                client_id: 'client',
+                extraQueryParams: 123456
+            });
+            subject.extraQueryParams.should.deep.equal({});
+        });
+
+        it("should set it if object", function () {
+            let subject = new OidcClientSettings({
+                client_id: 'client',
+            });
+            subject.extraQueryParams = { 'hd': 'domain.com' };
+            subject.extraQueryParams.should.deep.equal({ 'hd': 'domain.com' });
+        });
+
+        it("should clear it if not object", function() {
+            let subject = new OidcClientSettings({
+                client_id: 'client',
+                extraQueryParams: {
+                    'hd': 'domain.com',
+                }
+            });
+            subject.extraQueryParams = undefined;
+            subject.extraQueryParams.should.deep.equal({});
+        });
+    })
+
 });

--- a/test/unit/SigninRequest.spec.js
+++ b/test/unit/SigninRequest.spec.js
@@ -187,6 +187,15 @@ describe("SigninRequest", function() {
             subject.url.should.contain("request_uri=foo");
         });
 
+        it("should include extra query params", function() {
+            settings.extraQueryParams = {
+                'hd': 'domain.com',
+                'foo': 'bar'
+            };
+            subject = new SigninRequest(settings);
+            subject.url.should.contain('hd=domain.com&foo=bar');
+        });
+
     });
 
     describe("isOidc", function() {


### PR DESCRIPTION
Solution for issue #315.

Spec are as followed:
- only accepting `object`
- default value is `{}`
- can set initial value
- can get value
- can set new value
    - if value not an `object`, set to default value `{}`
- (key,value) couples are added to the end of the url
