### PR TITLE
[update] Add query param support.

### DIFF
--- a/src/SigninResponse.js
+++ b/src/SigninResponse.js
@@ -8,7 +8,8 @@ const OidcScope = "openid";
 export default class SigninResponse {
     constructor(url) {
 
-        var values = UrlUtility.parseUrlFragment(url, "#");
+        var delimiter = UrlUtility.hasFragment(url) ? "#" : "?";
+        var values = UrlUtility.parseUrlFragment(url, delimiter);
 
         this.error = values.error;
         this.error_description = values.error_description;

--- a/src/UrlUtility.js
+++ b/src/UrlUtility.js
@@ -54,4 +54,8 @@ export default class UrlUtility {
         
         return {};
     }
+
+    static hasFragment(url) {
+        return url.indexOf("#") >= 0;
+    }
 }


### PR DESCRIPTION
`signinRedirectCallback` method returns `No state in response` when the IdP server provide `state` and `code` params as query parameter because of the `SigninResponse` class parse only fragments.
This fix adds a process of checking if url contains fragments and, if not, parsing query parameters.