### PR TITLE
Make oidc-client ReactNative-friendly

### DIFF
--- a/src/Event.js
+++ b/src/Event.js
@@ -23,8 +23,8 @@ export default class Event {
 
     raise(...params) {
         Log.debug("Raising event: " + this._name);
-        for (var cb of this._callbacks) {
-            cb(...params);
+        for (let i = 0; i < this._callbacks.length; i++) {
+            this._callbacks[i](...params);
         }
     }
 }

--- a/src/ResponseValidator.js
+++ b/src/ResponseValidator.js
@@ -166,7 +166,8 @@ export default class ResponseValidator {
                 values = [values];
             }
 
-            for (let value of values) {
+            for (let i = 0; i < values.length; i++) {
+                let value = value[i];
                 if (!result[name]) {
                     result[name] = value;
                 }

--- a/src/ResponseValidator.js
+++ b/src/ResponseValidator.js
@@ -167,7 +167,7 @@ export default class ResponseValidator {
             }
 
             for (let i = 0; i < values.length; i++) {
-                let value = value[i];
+                let value = values[i];
                 if (!result[name]) {
                     result[name] = value;
                 }

--- a/src/State.js
+++ b/src/State.js
@@ -50,7 +50,7 @@ export default class State {
             Log.debug("got keys", keys);
 
             var promises = [];
-            for (let i = 0; i < keys; i++) {
+            for (let i = 0; i < keys.length; i++) {
                 let key = keys[i];
                 var p = storage.get(key).then(item => {
                     let remove = false;

--- a/src/State.js
+++ b/src/State.js
@@ -50,7 +50,8 @@ export default class State {
             Log.debug("got keys", keys);
 
             var promises = [];
-            for (let key of keys) {
+            for (let i = 0; i < keys; i++) {
+                let key = keys[i];
                 var p = storage.get(key).then(item => {
                     let remove = false;
 

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -5,7 +5,8 @@ var createWebpackConfig = function(options) {
     output: options.output,
     plugins: options.plugins,
     node: {
-      fs: 'empty' // Because of jsrsasign usage of fs
+      fs: 'empty', // Because of jsrsasign usage of fs
+      buffer: 'empty',
     },
     module: {
       loaders: [


### PR DESCRIPTION
These changes makes this lib RN-friendly, meaning that it is possible to require it from a RN app (#306). The app must still create navigators that suits RN of course.

One change is that the buffer lib is not included in the minified file(s).
The other change is to not use 'for (.. of ..)' constructs since that seems to be troublesome for JavaScriptCore (https://github.com/facebook/react-native/issues/4587) .