### PR TITLE
Add missing extraQueryParams

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -134,6 +134,7 @@ export interface OidcClientSettings {
   stateStore?: StateStore;
   ResponseValidatorCtor?: ResponseValidatorCtor;
   MetadataServiceCtor?: MetadataServiceCtor;
+  extraQueryParams?: any;
 }
 
 export class UserManager extends OidcClient {


### PR DESCRIPTION
Add missing extraQueryParams in the OidcClientSettings interface definition file.

- src/OidcClientSettings.js has a getter and setter named `extraQueryParams` but it's not exposed with the definition file. See `OidcClientSettings.js` line 188 to 197.