### PR TITLE
Expose oidc metadata in typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -111,6 +111,8 @@ export class OidcClient {
   processSignoutResponse(url: string, stateStore: StateStore): Promise<SignoutResponse>;
 
   clearStaleState(stateStore: StateStore): Promise<any>;
+
+  get metadataService(): MetadataService;
 }
 
 export interface OidcClientSettings {

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,7 +57,7 @@ export interface MetadataService {
 
   metadataUrl?: string;
 
-  getMetadata(): Promise<any>;
+  getMetadata(): Promise<OidcMetadata>;
 
   getIssuer(): Promise<string>;
 
@@ -304,4 +304,45 @@ export class CordovaPopupNavigator {
 
 export class CordovaIFrameNavigator {
   prepare(params: any): Promise<CordovaPopupWindow>;
+}
+
+
+export interface OidcMetadata {
+  issuer: string;
+  authorization_endpoint:string;
+  token_endpoint: string;
+  token_endpoint_auth_methods_supported:string[];
+  token_endpoint_auth_signing_alg_values_supported: string[];
+  userinfo_endpoint: string;
+  check_session_iframe: string;
+  end_session_endpoint: string;
+  jwks_uri: string;
+  registration_endpoint: string;
+  scopes_supported: string[];
+  response_types_supported: string[];
+  acr_values_supported: string[];
+  subject_types_supported: string[];
+  userinfo_signing_alg_values_supported: string[];
+  userinfo_encryption_alg_values_supported: string[];
+  userinfo_encryption_enc_values_supported: string[];
+  id_token_signing_alg_values_supported: string[];
+  id_token_encryption_alg_values_supported: string[];
+  id_token_encryption_enc_values_supported: string[];
+  request_object_signing_alg_values_supported: string[];
+  display_values_supported: string[];
+  claim_types_supported: string[];
+  claims_supported: string[];
+  claims_parameter_supported: boolean;
+  service_documentation: string;
+  ui_locales_supported: string[];
+
+  revocation_endpoint: string;
+  introspection_endpoint: string;
+  frontchannel_logout_supported: boolean;
+  frontchannel_logout_session_supported: boolean;
+  backchannel_logout_supported: boolean;
+  backchannel_logout_session_supported: boolean;
+  grant_types_supported: string[];
+  response_modes_supported: string[];
+  code_challenge_methods_supported: string[];
 }


### PR DESCRIPTION
This exposes the getter for the metadataService on the OidcClient class in typescript and also adds an interface for the returned metadata.