### PR TITLE
fix metadataService reference in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -112,7 +112,7 @@ export class OidcClient {
 
   clearStaleState(stateStore: StateStore): Promise<any>;
 
-  metadataService: MetadataService;
+  readonly metadataService: MetadataService;
 }
 
 export interface OidcClientSettings {

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,7 +112,7 @@ export class OidcClient {
 
   clearStaleState(stateStore: StateStore): Promise<any>;
 
-  get metadataService(): MetadataService;
+  metadataService: MetadataService;
 }
 
 export interface OidcClientSettings {


### PR DESCRIPTION
Sorry, my previous change on this introduced a typescript compile time error when the d.ts file is imported into a typescript project.
Seems that definition files cant use getters and setters, so I'm switching it to use a readonly property which behaves the same as the es6 getter implementation.
