### PR TITLE
Allow application/jwk-set+json JSON response type

### DIFF
--- a/src/JsonService.js
+++ b/src/JsonService.js
@@ -27,7 +27,7 @@ export class JsonService {
 
                 if (req.status === 200) {
                     var contentType = req.getResponseHeader("Content-Type");
-                    if (contentType && contentType.startsWith("application/json")) {
+                    if (contentType && (contentType.startsWith("application/json") || contentType.startsWith("application/jwk-set+json"))) {
                         try {
                             resolve(JSON.parse(req.responseText));
                         }


### PR DESCRIPTION
The jwks_uri endpoint returns a JSON Web Key Set which is specificed as
content type `application/jwk-set+json` in
https://tools.ietf.org/html/rfc7517. This change adds this content type
to the response validation logic so that jwks responses from providers
which actually return the correct content type work again.

Fixes: #609