### PR TITLE
Removed check for window.parent in notifyParent

### DIFF
--- a/src/IFrameWindow.js
+++ b/src/IFrameWindow.js
@@ -106,12 +106,10 @@ export class IFrameWindow {
     static notifyParent(url) {
         Log.debug("IFrameWindow.notifyParent");
 
-        if (window.parent && window !== window.parent) {
-            url = url || window.location.href;
-            if (url) {
-                Log.debug("IFrameWindow.notifyParent: posting url message to parent");
-                window.parent.postMessage(url, location.protocol + "//" + location.host);
-            }
+        url = url || window.location.href;
+        if (url) {
+            Log.debug("IFrameWindow.notifyParent: posting url message to parent");
+            window.parent.postMessage(url, location.protocol + "//" + location.host);
         }
     }
 }

--- a/src/IFrameWindow.js
+++ b/src/IFrameWindow.js
@@ -105,11 +105,12 @@ export class IFrameWindow {
 
     static notifyParent(url) {
         Log.debug("IFrameWindow.notifyParent");
-
-        url = url || window.location.href;
-        if (url) {
-            Log.debug("IFrameWindow.notifyParent: posting url message to parent");
-            window.parent.postMessage(url, location.protocol + "//" + location.host);
+        if (window.frameElement) {
+            url = url || window.location.href;
+            if (url) {
+                Log.debug("IFrameWindow.notifyParent: posting url message to parent");
+                window.parent.postMessage(url, location.protocol + "//" + location.host);
+            }
         }
     }
 }


### PR DESCRIPTION
Since window.parent is self referencing when no parent exists, this fix will make the postMessage call work both for iframe scenarios and for electron webview scenarios where there is no parent context.

**Why is this needed:**
Running a normal silent signin on a website from a UI test in Electron fails because the callback is not in a context with a parent. Electron does not run the callback in an iframe with a parent but in a electron webview which has no parent. 

If cross origin was not an issue the iframe check could be done more explicitly with if (window.frameElement) which works both in browsers and electron. 
But I am not sure that this check is needed at all. I am not sure what it is supposed to protect against? window.parent will always be defined.

What is expected to happen if the removed if is false? No postMessage is called and nothing works.
It will result in a frame timeout since no message comes back.

I hope you will consider this PR since it will make it possible for us to test our website in a headless Electron environment.
