### PR TITLE
Use client_secret for code exchange in Auth Code Flow

### DIFF
--- a/src/ResponseValidator.js
+++ b/src/ResponseValidator.js
@@ -237,11 +237,12 @@ export class ResponseValidator {
     _processCode(state, response) {
         var request = {
             client_id: state.client_id,
+            client_secret: this._settings.client_secret,
             code : response.code,
             redirect_uri: state.redirect_uri,
             code_verifier: state.code_verifier,
         };
-
+        
         return this._tokenClient.exchangeCode(request).then(tokenResponse => {
             
             for(var key in tokenResponse) {


### PR DESCRIPTION
Hi there, thanks for bringing out this lib :+1:. I've been following #552 since I'm interested in Oidc **code flow**. Testing 1.6.0-beta-1, I ran into a missing `client_secret` during code exchange (_processCode) resulting on a *invalid_client* error.

Hence this small pull request which I tested against my AWS Cognito provider. `client_secret` settings wasn't widely used so that I hope it's ok calling it like I did.