### PR TITLE
fix: window is not defined

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,9 @@ gulp.task('build-lib-sourcemap', ['jsrsasign'], function() {
     entry: npmEntry,
     output: {
         filename:'oidc-client.js',
-        libraryTarget:'umd'
+        libraryTarget:'umd',
+        // Workaround for https://github.com/webpack/webpack/issues/6642
+        globalObject: 'this'
     },
     plugins: [],
     devtool:'inline-source-map'
@@ -34,6 +36,8 @@ gulp.task('build-lib-min', ['jsrsasign'], function() {
     output: {
         filename:'oidc-client.min.js',
         libraryTarget:'umd',
+        // Workaround for https://github.com/webpack/webpack/issues/6642
+        globalObject: 'this'
     },
     plugins: [],
     devtool: false,


### PR DESCRIPTION
fixes #701 

Issue:
NodeJS throws `ReferenceError: window is not defined` when `oidc-client` is imported.

Solution:
Actually this is not an `oidc-client` issue. There is an issue in webpack 4 which generates invalid code.
See  https://github.com/webpack/webpack/issues/6642
To workaround this issue, we define the globalObject to `this`.
`this` is `window` in Browsers and `global` in NodeJS.