### PR TITLE
add npm natives module to devDependencies to fix gulp build fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-client",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4845,9 +4845,9 @@
       }
     },
     "natives": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.3.tgz",
-      "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
       "dev": true
     },
     "negotiator": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "mocha": "^5.2.0",
+    "natives": "^1.1.6",
     "open": "0.0.5",
     "uglifyjs-webpack-plugin": "^1.2.7",
     "webpack": "^4.16.0",


### PR DESCRIPTION
Please see #719 for more detail.

Both Node 10 and Node 8 can run `npm run build` without error message now.