### PR TITLE
remove duplicate dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,5 @@
   "dependencies": {
     "jsrsasign": "^8.0.12"
   },
-  "optionalDependencies": {
-    "babel-polyfill": ">=6.9.1"
-  },
   "typings": "index.d.ts"
 }


### PR DESCRIPTION
babel-polyfill is already listed in devDependencies so the entry for optionalDependencies is redundant

Resolves #733 