### PR TITLE
Added support for extraQueryParams in the Single Logout url

### DIFF
--- a/src/OidcClient.js
+++ b/src/OidcClient.js
@@ -123,12 +123,13 @@ export class OidcClient {
         });
     }
 
-    createSignoutRequest({id_token_hint, data, state, post_logout_redirect_uri} = {},
+    createSignoutRequest({id_token_hint, data, state, post_logout_redirect_uri, extraQueryParams } = {},
         stateStore
     ) {
         Log.debug("OidcClient.createSignoutRequest");
 
         post_logout_redirect_uri = post_logout_redirect_uri || this._settings.post_logout_redirect_uri;
+        extraQueryParams = extraQueryParams || this._settings.extraQueryParams;
 
         return this._metadataService.getEndSessionEndpoint().then(url => {
             if (!url) {
@@ -142,7 +143,8 @@ export class OidcClient {
                 url,
                 id_token_hint,
                 post_logout_redirect_uri,
-                data: data || state
+                data: data || state,
+                extraQueryParams
             });
 
             var signoutState = request.state;

--- a/src/SignoutRequest.js
+++ b/src/SignoutRequest.js
@@ -6,7 +6,7 @@ import { UrlUtility } from './UrlUtility';
 import { State } from './State';
 
 export class SignoutRequest {
-    constructor({url, id_token_hint, post_logout_redirect_uri, data}) {
+    constructor({url, id_token_hint, post_logout_redirect_uri, data, extraQueryParams}) {
         if (!url) {
             Log.error("SignoutRequest.ctor: No url passed");
             throw new Error("url");
@@ -24,6 +24,10 @@ export class SignoutRequest {
 
                 url = UrlUtility.addQueryParam(url, "state", this.state.id);
             }
+        }
+
+        for(let key in extraQueryParams){
+            url = UrlUtility.addQueryParam(url, key, extraQueryParams[key])
         }
 
         this.url = url;

--- a/test/unit/SignoutRequest.spec.js
+++ b/test/unit/SignoutRequest.spec.js
@@ -80,6 +80,15 @@ describe("SignoutRequest", function() {
             url.should.contain("state=" + subject.state.id);
         });
 
+        it("should include extra query params", function() {
+            settings.extraQueryParams = {
+                'TargetResource': 'logouturl.com',
+                'InErrorResource': 'errorurl.com'
+            };
+            subject = new SignoutRequest(settings);
+            subject.url.should.contain('TargetResource=logouturl.com&InErrorResource=errorurl.com');
+        });
+
     });
 
 });


### PR DESCRIPTION
As promised @brockallen, this PR fixes the issue #737.

**Changes :**
- `OidcClient.js` : added `extraQueryParams` to `createSignoutRequest()`
- `SignoutRequest.js` : added `extraQueryParams` to `SignoutRequest`
- `SignoutRequest.spec.js` : added a test case `should include extra query params` with 2 extra parameters

Can't wait to see this merged. Thank you!
