### PR TITLE
Use the configured scopes when silently renewing

### DIFF
--- a/src/UserManager.js
+++ b/src/UserManager.js
@@ -280,7 +280,7 @@ export class UserManager extends OidcClient {
         args.redirect_uri = url;
         args.prompt = "none";
         args.response_type = args.response_type || this.settings.query_status_response_type;
-        args.scope = "openid";
+        args.scope = args.scope || this.settings.scope || "openid";
 
         return this._signinStart(args, this._iframeNavigator, {
             startUrl: url,


### PR DESCRIPTION
In testing OIDC session management using a client build on oidc-client.js, I found that triggering a change to the session caused the client to fetch a new access token using only the `openid` scope, meaning all the original scopes I had request are lost (ie `email`, `profile`, `name`, etc).

This pull request uses the user-configured scopes instead of defaulting to only `openid`.