### PR TITLE
Improve typings for UserManager.getUser() and signinRedirectCallback()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -167,7 +167,7 @@ export class UserManager extends OidcClient {
   signinRedirectCallback(url?: string): Promise<User>;
 
   signoutRedirect(args?: any): Promise<any>;
-  signoutRedirectCallback(url?: string): Promise<any>;
+  signoutRedirectCallback(url?: string): Promise<SignoutResponse>;
 
   signoutPopup(args?: any): Promise<any>;
   signoutPopupCallback(url?: string, keepOpen?: boolean): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -153,7 +153,7 @@ export class UserManager extends OidcClient {
 
   clearStaleState(): Promise<void>;
 
-  getUser(): Promise<User>;
+  getUser(): Promise<User | null>;
   storeUser(user:User): Promise<void>;
   removeUser(): Promise<void>;
 

--- a/src/UserManager.js
+++ b/src/UserManager.js
@@ -93,13 +93,11 @@ export class UserManager extends OidcClient {
     }
     signinRedirectCallback(url) {
         return this._signinEnd(url || this._redirectNavigator.url).then(user => {
-            if (user) {
-                if (user.profile && user.profile.sub) {
-                    Log.info("UserManager.signinRedirectCallback: successful, signed in sub: ", user.profile.sub);
-                }
-                else {
-                    Log.info("UserManager.signinRedirectCallback: no sub");
-                }
+            if (user.profile && user.profile.sub) {
+                Log.info("UserManager.signinRedirectCallback: successful, signed in sub: ", user.profile.sub);
+            }
+            else {
+                Log.info("UserManager.signinRedirectCallback: no sub");
             }
 
             return user;


### PR DESCRIPTION
The Promise returned by UserManager.getUser() can resolve to a value of `null` (e.g., when a user is not currently authenticated/loaded/cached). The return type is updated to indicate that the resolved value may be `null`.

Someone with more intimate knowledge of this project should probably review other function signatures to determine if would be appropriate to specify `null` as a possible result. This is important for TypeScript projects with the `strictNullChecks` option enabled to get IDE assistance and compiler errors about things that may possibly be null.

I tried to investigate a couple other methods that return `Promise<User>` to see if they should be updated to`Promise<Use | null>`, but it was not trivial. Some of them internally use other private methods that return a Promise that may resolve to null, but they may also be implemented in a way that guarantees that code path may never actually be taken. 

The type of something should only include `| null` if (and only if) a null value is actually possibly at run-time by design.  Adding `| null` to a type unnecessarily is just as bad as not having `| null` on something that may be null. An unnecessary `| null` typing forces TypeScript users to make a decision about how to handle a null value. If the value is never intended to be null by design, then it causes confusion where the developer will either write a dead branch of code that will never execute, or will have to determine that the typings are incorrect and add a non-null assertion to force the compiler to believe it will never be null.

All of this to say that I, as a new user of this library, was only able to confidently determine the correct signature for this one specific method, but I hope someone else with more knowledge of this code now apply the same thought process in reviewing other function signatures, property types in interfaces, etc.

NOTE: It's also important to consider that `undefined` and `null` are distinct types and values, so watch out for code that might sometimes use the value of an optional property of an object (`undefined` if not present), and other times explicitly use a value of `null`. This creates inconsistency. The typings would have to specify `| null | undefined` to be correct, which adds confusion about why it could be either. Do `null` and `undefined` mean different things to this library, or was it just the result of sloppy code? This is why many projects now exclusively use `undefined` to represent non-presence of values, avoiding `null` altogether.