### PR TITLE
Add module key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.7.0",
   "description": "OpenID Connect (OIDC) & OAuth2 client library",
   "main": "lib/oidc-client.min.js",
+  "module": "index.js",
   "scripts": {
     "build": "gulp build",
     "start": "node samples/VanillaJS/server.js",


### PR DESCRIPTION
Add module key to allow tools capable of reading ES6 modules to use the ES6 version of the package.