### PR TITLE
Improve typings for UserManagerEvents callback signatures

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -187,20 +187,28 @@ export interface UserManagerEvents extends AccessTokenEvents {
   load(user: User): any;
   unload(): any;
 
-  addUserLoaded(callback: (...ev: any[]) => void): void;
-  removeUserLoaded(callback: (...ev: any[]) => void): void;
+  addUserLoaded(callback: UserManagerEvents.UserLoadedCallback): void;
+  removeUserLoaded(callback: UserManagerEvents.UserLoadedCallback): void;
 
-  addUserUnloaded(callback: (...ev: any[]) => void): void;
-  removeUserUnloaded(callback: (...ev: any[]) => void): void;
+  addUserUnloaded(callback: UserManagerEvents.UserUnloadedCallback): void;
+  removeUserUnloaded(callback: UserManagerEvents.UserUnloadedCallback): void;
 
-  addSilentRenewError(callback: (...ev: any[]) => void): void;
-  removeSilentRenewError(callback: (...ev: any[]) => void): void;
+  addSilentRenewError(callback: UserManagerEvents.SilentRenewErrorCallback): void;
+  removeSilentRenewError(callback: UserManagerEvents.SilentRenewErrorCallback): void;
 
-  addUserSignedOut(callback: (...ev: any[]) => void): void;
-  removeUserSignedOut(callback: (...ev: any[]) => void): void;
+  addUserSignedOut(callback: UserManagerEvents.UserSignedOutCallback): void;
+  removeUserSignedOut(callback: UserManagerEvents.UserSignedOutCallback): void;
 
-  addUserSessionChanged(callback: (...ev: any[]) => void): void;
-  removeUserSessionChanged(callback: (...ev: any[]) => void): void;
+  addUserSessionChanged(callback: UserManagerEvents.UserSessionChangedCallback): void;
+  removeUserSessionChanged(callback: UserManagerEvents.UserSessionChangedCallback): void;
+}
+
+export namespace UserManagerEvents {
+  export type UserLoadedCallback = (user: User) => void;
+  export type UserUnloadedCallback = () => void;
+  export type SilentRenewErrorCallback = (error: Error) => void;
+  export type UserSignedOutCallback = () => void;
+  export type UserSessionChangedCallback = () => void;
 }
 
 export interface UserManagerSettings extends OidcClientSettings {

--- a/src/UserManagerEvents.js
+++ b/src/UserManagerEvents.js
@@ -60,9 +60,9 @@ export class UserManagerEvents extends AccessTokenEvents {
     removeUserSignedOut(cb) {
         this._userSignedOut.removeHandler(cb);
     }
-    _raiseUserSignedOut(e) {
+    _raiseUserSignedOut() {
         Log.debug("UserManagerEvents._raiseUserSignedOut");
-        this._userSignedOut.raise(e);
+        this._userSignedOut.raise();
     }
 
     addUserSessionChanged(cb) {
@@ -71,8 +71,8 @@ export class UserManagerEvents extends AccessTokenEvents {
     removeUserSessionChanged(cb) {
         this._userSessionChanged.removeHandler(cb);
     }
-    _raiseUserSessionChanged(e) {
+    _raiseUserSessionChanged() {
         Log.debug("UserManagerEvents._raiseUserSessionChanged");
-        this._userSessionChanged.raise(e);
+        this._userSessionChanged.raise();
     }
 }


### PR DESCRIPTION
The signatures in the TypeScript typings for all UserManagerEvents callbacks were all generically functions that can accept any parameters.

I have reviewed the source code that raises each of the events to confirm what kinds of arguments are actually passed to each callback, and updated the typings with appropriate signatures for each callback.

This will greatly improved type safety and type inference when writing callback implementations in TypeScript.