### PR TITLE
add setting for default endpoints

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
-sample/
+samples/
 test/
 .babelrc

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,6 +121,7 @@ export interface OidcClientSettings {
   authority?: string;
   readonly metadataUrl?: string;
   metadata?: any;
+  useDefaultEndpoints?: boolean;
   signingKeys?: any[];
   client_id?: string;
   client_secret?: string;
@@ -304,7 +305,7 @@ export class User {
   profile: any;
   expires_at: number;
   state: any;
-  
+
   toStorageString(): string;
 
   readonly expires_in: number | undefined;

--- a/src/MetadataService.js
+++ b/src/MetadataService.js
@@ -63,15 +63,21 @@ export class MetadataService {
     }
 
     getAuthorizationEndpoint() {
-        return this._getMetadataProperty("authorization_endpoint");
+        return  (this._settings.useDefaultEndpoints)
+            ? Promise.resolve(this._settings.authority + '/connect/authorize')
+            : this._getMetadataProperty("authorization_endpoint");
     }
 
     getUserInfoEndpoint() {
-        return this._getMetadataProperty("userinfo_endpoint");
+        return  (this._settings.useDefaultEndpoints)
+            ? Promise.resolve(this._settings.authority + '/connect/userinfo')
+            : this._getMetadataProperty("userinfo_endpoint");
     }
 
     getTokenEndpoint(optional=true) {
-        return this._getMetadataProperty("token_endpoint", optional);
+        return  (this._settings.useDefaultEndpoints)
+            ? Promise.resolve(this._settings.authority + '/connect/token')
+            : this._getMetadataProperty("token_endpoint", optional);
     }
 
     getCheckSessionIframe() {

--- a/src/OidcClientSettings.js
+++ b/src/OidcClientSettings.js
@@ -16,7 +16,7 @@ const DefaultClockSkewInSeconds = 60 * 5;
 export class OidcClientSettings {
     constructor({
         // metadata related
-        authority, metadataUrl, metadata, signingKeys,
+        authority, metadataUrl, metadata, useDefaultEndpoints, signingKeys,
         // client related
         client_id, client_secret, response_type = DefaultResponseType, scope = DefaultScope,
         redirect_uri, post_logout_redirect_uri,
@@ -37,6 +37,7 @@ export class OidcClientSettings {
         this._authority = authority;
         this._metadataUrl = metadataUrl;
         this._metadata = metadata;
+        this._useDefaultEndpoints = useDefaultEndpoints;
         this._signingKeys = signingKeys;
 
         this._client_id = client_id;
@@ -157,6 +158,12 @@ export class OidcClientSettings {
     }
     set metadata(value) {
         this._metadata = value;
+    }
+    get useDefaultEndpoints() {
+        return this._useDefaultEndpoints;
+    }
+    set useDefaultEndpoints(value) {
+        this._useDefaultEndpoints = value;
     }
 
     get signingKeys() {


### PR DESCRIPTION
I'd like to eliminate the initial metadata fetch when using the default authorize endpoints (i.e. when calling signinRedirect).  And I don't want to provide the metadata to the client manually.

This PR adds a setting `useDefaultEndpoints`; if true it does not fetch metadata to learn the endpoint address, but instead assumes `this.authority + '/connect/authorize';`.  It will still fetch metadata when looking for any other properties.

This seems to be working fine for me, but please let me know if I'm headed for trouble with this.

I understand my need here may be too specific for the wider audience, but thought I'd ask. (So I don't have to maintain a fork!)
