### PR TITLE
Support for refresh token expiration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,12 @@ export interface AccessTokenEvents {
 
   addAccessTokenExpired(callback: (...ev: any[]) => void): void;
   removeAccessTokenExpired(callback: (...ev: any[]) => void): void;
+
+  addRefreshTokenExpiring(callback: (...ev: any[]) => void): void;
+  removeRefreshTokenExpiring(callback: (...ev: any[]) => void): void;
+
+  addRefreshTokenExpired(callback: (...ev: any[]) => void): void;
+  removeRefreshTokenExpired(callback: (...ev: any[]) => void): void;
 }
 
 export class InMemoryWebStorage {

--- a/index.d.ts
+++ b/index.d.ts
@@ -267,6 +267,8 @@ export interface SigninResponse {
 
   readonly expired: boolean | undefined;
   readonly expires_in: number | undefined;
+  readonly refresh_expired: number | undefined;
+  readonly refresh_expires_in: number | undefined;
   readonly isOpenIdConnect: boolean;
   readonly scopes: string[];
 }
@@ -309,6 +311,8 @@ export class User {
 
   readonly expires_in: number | undefined;
   readonly expired: boolean | undefined;
+  readonly refresh_expires_in: number | undefined;
+  readonly refresh_expired: boolean | undefined;
   readonly scopes: string[];
 }
 

--- a/src/SigninResponse.js
+++ b/src/SigninResponse.js
@@ -24,6 +24,7 @@ export class SigninResponse {
         this.profile = undefined; // will be set from ResponseValidator
 
         this.expires_in = values.expires_in;
+        this.refresh_expires_in = values.refresh_expires_in;
     }
 
     get expires_in() {
@@ -45,6 +46,30 @@ export class SigninResponse {
         let expires_in = this.expires_in;
         if (expires_in !== undefined) {
             return expires_in <= 0;
+        }
+        return undefined;
+    }
+
+    get refresh_expires_in() {
+        if (this.refresh_expires_at) {
+            let now = parseInt(Date.now() / 1000);
+            return this.refresh_expires_at - now;
+        }
+        return undefined;
+    }
+
+    set refresh_expires_in(value) {
+        let refresh_expires_in = parseInt(value);
+        if (typeof refresh_expires_in === 'number' && refresh_expires_in > 0) {
+            let now = parseInt(Date.now() / 1000);
+            this.refresh_expires_at = now + refresh_expires_in;
+        }
+    }
+
+    get refresh_expired() {
+        let refresh_expires_in = this.refresh_expires_in;
+        if (refresh_expires_in !== undefined) {
+            return refresh_expires_in <= 0;
         }
         return undefined;
     }

--- a/src/User.js
+++ b/src/User.js
@@ -4,7 +4,7 @@
 import { Log } from './Log.js';
 
 export class User {
-    constructor({id_token, session_state, access_token, refresh_token, token_type, scope, profile, expires_at, state}) {
+    constructor({id_token, session_state, access_token, refresh_token, token_type, scope, profile, expires_at, refresh_expires_at, state}) {
         this.id_token = id_token;
         this.session_state = session_state;
         this.access_token = access_token;
@@ -13,6 +13,7 @@ export class User {
         this.scope = scope;
         this.profile = profile;
         this.expires_at = expires_at;
+        this.refresh_expires_at = refresh_expires_at;
         this.state = state;
     }
 
@@ -39,6 +40,29 @@ export class User {
         return undefined;
     }
 
+    get refresh_expires_in() {
+        if (this.refresh_expires_at) {
+            let now = parseInt(Date.now() / 1000);
+            return this.refresh_expires_at - now;
+        }
+    }
+
+    set refresh_expires_in(value) {
+        let refresh_expires_in = parseInt(value);
+        if (typeof refresh_expires_in === 'number' && refresh_expires_in > 0) {
+            let now = parseInt(Date.now() / 1000);
+            this.refresh_expires_at = now + refresh_expires_in;
+        }
+    }
+
+    get refresh_expired() {
+        let refresh_expires_in = this.refresh_expires_in;
+        if (refresh_expires_in !== undefined) {
+            return refresh_expires_in <= 0;
+        }
+        return undefined;
+    }
+
     get scopes() {
         return (this.scope || "").split(" ");
     }
@@ -53,7 +77,8 @@ export class User {
             token_type: this.token_type,
             scope: this.scope,
             profile: this.profile,
-            expires_at: this.expires_at
+            expires_at: this.expires_at,
+            refresh_expires_at: this.refresh_expires_at
         });
     }
 

--- a/src/UserManager.js
+++ b/src/UserManager.js
@@ -187,6 +187,7 @@ export class UserManager extends OidcClient {
                         user.access_token = result.access_token;
                         user.refresh_token = result.refresh_token || user.refresh_token;
                         user.expires_in = result.expires_in;
+                        user.refresh_expires_in = result.refresh_expires_in;
 
                         return this.storeUser(user).then(()=>{
                             this._events.load(user);

--- a/test/unit/AccessTokenEvents.spec.js
+++ b/test/unit/AccessTokenEvents.spec.js
@@ -30,12 +30,17 @@ describe("AccessTokenEvents", function () {
     let subject;
     let accessTokenExpiringTimer;
     let accessTokenExpiredTimer;
+    let refreshTokenExpiringTimer;
+    let refreshTokenExpiredTimer;
 
     beforeEach(function () {
         accessTokenExpiringTimer = new StubTimer();
         accessTokenExpiredTimer = new StubTimer();
+        refreshTokenExpiringTimer = new StubTimer();
+        refreshTokenExpiredTimer = new StubTimer();
         subject = new AccessTokenEvents({
-            accessTokenExpiringTimer, accessTokenExpiredTimer
+            accessTokenExpiringTimer, accessTokenExpiredTimer,
+            refreshTokenExpiringTimer, refreshTokenExpiredTimer
         });
     });
 
@@ -43,57 +48,74 @@ describe("AccessTokenEvents", function () {
 
         it("should use default expiringNotificationTime", function () {
             subject._accessTokenExpiringNotificationTime.should.equal(60);
+            subject._refreshTokenExpiringNotificationTime.should.equal(60);
         });
 
     });
 
     describe("load", function () {
 
-        it("should cancel existing timers", function () {
+        it("should cancel existing access and refresh timers", function () {
             subject.load({});
 
             accessTokenExpiringTimer.cancelWasCalled.should.be.true;
             accessTokenExpiredTimer.cancelWasCalled.should.be.true;
+
+            refreshTokenExpiringTimer.cancelWasCalled.should.be.true;
+            refreshTokenExpiredTimer.cancelWasCalled.should.be.true;
         });
 
-        it("should initialize timers", function () {
+        it("should initialize access and refresh timers", function () {
             subject.load({
                 access_token:"token",
-                expires_in : 70
+                expires_in : 70,
+                refresh_token: "token",
+                refresh_expires_in: 140
             });
 
             accessTokenExpiringTimer.duration.should.equal(10);
             accessTokenExpiredTimer.duration.should.equal(71);
+            refreshTokenExpiringTimer.duration.should.equal(80);
+            refreshTokenExpiredTimer.duration.should.equal(141);
         });
 
-        it("should immediately schedule expiring timer if expiration is soon", function () {
+        it("should immediately schedule expiring access and refresh timer if expiration is soon", function () {
             subject.load({
                 access_token:"token",
-                expires_in : 10
+                expires_in : 10,
+                refresh_token: "token",
+                refresh_expires_in: 10
             });
 
             accessTokenExpiringTimer.duration.should.equal(1);
+            refreshTokenExpiringTimer.duration.should.equal(1);
         });
 
-        it("should not initialize expiring timer if already expired", function () {
+        it("should not initialize expiring access and refresh timer if already expired", function () {
             subject.load({
                 access_token:"token",
-                expires_in : 0
+                expires_in : 0,
+                refresh_token: "token",
+                refresh_expires_in: 0
             });
 
             assert.isUndefined(accessTokenExpiringTimer.duration);
+            assert.isUndefined(refreshTokenExpiringTimer.duration);
         });
 
-        it("should initialize expired timer if already expired", function () {
+        it("should initialize expired access and refresh timer if already expired", function () {
             subject.load({
                 access_token:"token",
-                expires_in : 0
+                expires_in : 0,
+                refresh_token: "token",
+                refresh_expires_in: 0
             });
 
             accessTokenExpiredTimer.duration.should.equal(1);
+            refreshTokenExpiredTimer.duration.should.equal(1);
         });
 
-        it("should not initialize timers if no access token", function () {
+        it("should not initialize access token timers if no access token", function () {
             subject.load({
                 expires_in : 70
             });
@@ -102,7 +124,16 @@ describe("AccessTokenEvents", function () {
             assert.isUndefined(accessTokenExpiredTimer.duration);
         });
 
-        it("should not initialize timers if no expiration on access token", function () {
+        it("should not initialize refresh token timers if no refresh token", function () {
+            subject.load({
+                refresh_expires_in: 70
+            });
+
+            assert.isUndefined(refreshTokenExpiringTimer.duration);
+            assert.isUndefined(refreshTokenExpiredTimer.duration);
+        });
+
+        it("should not initialize access token timers if no expiration on access token", function () {
             subject.load({
                 access_token:"token"
             });
@@ -110,16 +141,28 @@ describe("AccessTokenEvents", function () {
             assert.isUndefined(accessTokenExpiringTimer.duration);
             assert.isUndefined(accessTokenExpiredTimer.duration);
         });
+
+        it("should not initialize refresh token timers if no expiration on refresh token", function () {
+            subject.load({
+                refresh_token: "token"
+            });
+
+            assert.isUndefined(refreshTokenExpiringTimer.duration);
+            assert.isUndefined(refreshTokenExpiredTimer.duration);
+        })
     });
 
     describe("unload", function () {
 
-        it("should cancel timers", function () {
+        it("should cancel access and refresh token timers", function () {
 
             subject.unload();
 
             accessTokenExpiringTimer.cancelWasCalled.should.be.true;
             accessTokenExpiredTimer.cancelWasCalled.should.be.true;
+
+            refreshTokenExpiringTimer.cancelWasCalled.should.be.true;
+            refreshTokenExpiredTimer.cancelWasCalled.should.be.true;
         });
 
     });

--- a/test/unit/SigninResponse.spec.js
+++ b/test/unit/SigninResponse.spec.js
@@ -83,6 +83,25 @@ describe("SigninResponse", function () {
             expect(subject.expires_at).to.be.undefined;
         });
 
+        it("should read refresh_expires_in", function () {
+            let subject = new SigninResponse("refresh_expires_in=10");
+            subject.refresh_expires_in.should.equal(10);
+        });
+
+        it("should calculate refresh_expires_at", function () {
+            let subject = new SigninResponse("refresh_expires_in=10");
+            subject.refresh_expires_at.should.equal(parseInt((Date.now() / 1000) + 10));
+        });
+
+        it("should not read invalid refresh_expires_in", function () {
+            let subject = new SigninResponse("refresh_expires_in=foo");
+            expect(subject.refresh_expires_in).to.be.undefined;
+            expect(subject.refresh_expires_at).to.be.undefined;
+
+            subject = new SigninResponse("refresh_expires_in=-10");
+            expect(subject.refresh_expires_in).to.be.undefined;
+            expect(subject.refresh_expires_at).to.be.undefined;
+        });
     });
 
     describe("scopes", function () {
@@ -128,6 +147,40 @@ describe("SigninResponse", function () {
                 return 1100 * 1000; // ms
             }
             subject.expired.should.be.true;
+            Date.now = oldNow;
+        });
+    });
+
+    describe("refresh_expires_in", function () {
+        it("should calculate how much time left", function () {
+            var oldNow = Date.now;
+            Date.now = function () {
+                return 1000 * 1000; // ms
+            };
+            let subject = new SigninResponse("refresh_expires_in=100");
+            subject.refresh_expires_in.should.equal(100);
+
+            Date.now = function () {
+                return 1050 * 1000; // ms
+            };
+            subject.refresh_expires_in.should.equal(50);
+            Date.now = oldNow;
+        });
+    });
+
+    describe("refresh_expired", function () {
+        it("should calculate how much time left", function () {
+            var oldNow = Date.now;
+            Date.now = function () {
+                return 1000 * 1000; // ms
+            };
+            let subject = new SigninResponse("refresh_expires_in=100");
+            subject.refresh_expired.should.be.false;
+
+            Date.now = function () {
+                return 1100 * 1000; // ms
+            };
+            subject.refresh_expired.should.be.true;
             Date.now = oldNow;
         });
     });


### PR DESCRIPTION
Adds support for refresh token expiration time.

- Parses `refresh_expires_in` from signin response
- Adds `refresh_expired_in` and `refresh_expired` to `User`
- Adds expiring event and expired event for refresh tokens

I added the refresh token events to the `AccessTokenEvent` class. Typically, I'd recommend either
1. Renaming `AccessTokenEvents` to `TokenEvents` or
2. Adding a new `RefreshTokenEvents` class

However, I didn't rename the class to prevent breaking changes for users that use the `AccessTokenEvent` class directly and I didn't add a new `RefreshTokenEvents` class because `UserManager` class extends `AccessTokenEvents`.

Closes #853