### PR TITLE
Dependency and import tidy-up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-client",
-  "version": "1.7.1",
+  "version": "1.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1172,8 +1172,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-      "dev": true
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "big.js": {
       "version": "3.2.0",
@@ -1591,12 +1590,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
-      "dev": true
-    },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -1865,8 +1858,7 @@
     "core-js": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
-      "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==",
-      "dev": true
+      "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1956,8 +1948,7 @@
     "crypto-js": {
       "version": "3.1.9-1",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=",
-      "dev": true
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
     },
     "cyclist": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
   },
   "homepage": "https://github.com/IdentityModel/oidc-client-js",
   "dependencies": {
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "core-js": "^2.6.4",
+    "crypto-js": "^3.1.9-1",
+    "base64-js": "^1.3.0"
   },
   "devDependencies": {
     "babel-core": "^6.7.2",
@@ -40,10 +43,7 @@
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
-    "base64-js": "^1.3.0",
     "chai": "^4.2.0",
-    "core-js": "^2.6.4",
-    "crypto-js": "^3.1.9-1",
     "express": "^4.16.4",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",

--- a/src/crypto/rsa.js
+++ b/src/crypto/rsa.js
@@ -18,9 +18,11 @@ http://www-cs-students.stanford.edu/~tjw/jsbn/LICENSE
  * - Perform common base64 encoding/decoding tasks.
  */
 
-import { BigInteger } from 'jsbn';
+import JSBN from 'jsbn';
 import SHA256 from 'crypto-js/sha256';
 import base64Js from 'base64-js';
+
+var BigInteger = JSBN.BigInteger;
 
 /*! (c) Tom Wu | http://www-cs-students.stanford.edu/~tjw/jsbn/
  */


### PR DESCRIPTION
This change moves required dependencies that were added to `devDependencies` (sorry, my bad!) into `dependencies` and imports the object exported by the `jsbn` dependency and then uses `BigInteger` out of its default export. This syntax is ES6 module spec-compliant, whereas the previous way of importing it wasn't (again, my bad).

In terms of the distributable, this should change nothing - the benefits are for consumers who install this library via npm and build parts of it.