### PR TITLE
Add CircleCI building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,47 @@
+version: 2.1
+
+commands:
+  test-nodejs:
+    steps:
+      - run:
+          name: Versions
+          command: npm version
+      - checkout
+      - restore_cache:
+          keys:
+            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-master-{{ .Environment.CIRCLE_JOB }}
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Test
+          command: npm test
+      - save_cache:
+          key: v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
+          paths:
+            - ~/.npm/_cacache
+
+jobs:
+  node-v8:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - test-nodejs
+  node-v10:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - test-nodejs
+  node-v12:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - test-nodejs
+
+workflows:
+  node-multi-build:
+    jobs:
+      - node-v8
+      - node-v10
+      - node-v12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ commands:
       - run:
           name: Install dependencies
           command: npm ci
+       - run:
+         name: NPM Audit
+         command: npm audit --audit-level=moderate
       - run:
           name: Test
           command: npm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![npm package](https://badge.fury.io/js/oidc-client.svg)](https://www.npmjs.com/package/oidc-client)
+[![CircleCI](https://circleci.com/gh/IdentityModel/oidc-client-js/tree/dev.svg?style=svg)](https://circleci.com/gh/IdentityModel/oidc-client-js/tree/dev)
 
 # oidc-client
 


### PR DESCRIPTION
This will allow all PR's to be automatically checked against current (as of July of 2019) LTS versions of node. Currently this would be node 8, 10, and 12 (Node 12 becomes LTS on 2019-10-22)

The following screenshot is from my fork once the circle files contained in this PR were applied and I authorized circle access to my public git repositories.

![Screen Shot 2019-07-23 at 4 59 58 PM](https://user-images.githubusercontent.com/3507512/61747660-54a9d400-ad6c-11e9-8589-35d4c03e9e1c.png)
