### PR TITLE
fixed duplicated import of 'core-js/fn/object/assign'

### DIFF
--- a/polyfills.js
+++ b/polyfills.js
@@ -7,7 +7,6 @@
 import 'core-js/es6/promise';
 import 'core-js/fn/function/bind';
 import 'core-js/fn/object/assign';
-import 'core-js/fn/object/assign';
 import 'core-js/fn/array/find';
 import 'core-js/fn/array/some';
 import 'core-js/fn/array/is-array';


### PR DESCRIPTION
A minor change that removes duplicated import of 'core-js/fn/object/assign' polyfill for 'slim' bundle version.