### PR TITLE
Remove the check for "inside a frame"

### DIFF
--- a/src/IFrameWindow.js
+++ b/src/IFrameWindow.js
@@ -105,12 +105,10 @@ export class IFrameWindow {
 
     static notifyParent(url) {
         Log.debug("IFrameWindow.notifyParent");
-        if (window.frameElement) {
-            url = url || window.location.href;
-            if (url) {
-                Log.debug("IFrameWindow.notifyParent: posting url message to parent");
-                window.parent.postMessage(url, location.protocol + "//" + location.host);
-            }
+        url = url || window.location.href;
+        if (url) {
+            Log.debug("IFrameWindow.notifyParent: posting url message to parent");
+            window.parent.postMessage(url, location.protocol + "//" + location.host);
         }
     }
 }


### PR DESCRIPTION
This pull request removed the check for an existing parent or containing frame before doing the postMessage call in the checksession frame.

The check for if this is running inside a container does not provide any value in my opinion other than to make it more difficult to get it right in all kinds of browser implementations.

This change will fix the original issue with cypress with same origin iframes and with cross origin iframes as mentioned in this comment: https://github.com/IdentityModel/oidc-client-js/pull/676#issuecomment-522446218
