### PR TITLE
fix: Angular 8 build error:

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,11 +36,11 @@ export class InMemoryWebStorage {
 }
 
 export class Log {
-  static readonly NONE: number;
-  static readonly ERROR: number;
-  static readonly WARN: number;
-  static readonly INFO: number;
-  static readonly DEBUG: number;
+  static readonly NONE = 0;
+  static readonly ERROR = 1;
+  static readonly WARN = 2;
+  static readonly INFO = 3;
+  static readonly DEBUG = 4;
 
   static reset(): void;
 


### PR DESCRIPTION
```
oidc-client/index.ts(39,19): Error during template compile of 'Log'
  Only initialized variables and constants can be referenced in decorators because the value of this variable is needed by the template compiler.
```

Fixes #953