### PR TITLE
update typescript definition with User.fromStorageString static method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -320,6 +320,7 @@ export class User {
   state: any;
 
   toStorageString(): string;
+  static fromStorageString(storageString: string): User;
 
   readonly expires_in: number | undefined;
   readonly expired: boolean | undefined;


### PR DESCRIPTION
Typescript definition is missing User.fromStorageString static method. This pull request adds this method to the typescript definition.