### PR TITLE
Minor fix in readSignoutResponseState

### DIFF
--- a/src/OidcClient.js
+++ b/src/OidcClient.js
@@ -183,7 +183,7 @@ export class OidcClient {
                 return Promise.reject(new ErrorResponse(response));
             }
 
-            return Promise.resolve({undefined, response});
+            return Promise.resolve({state: undefined, response});
         }
 
         var stateKey = response.state;


### PR DESCRIPTION
By chance I found what I think is an error.
The this method returns `{undefined: undefined, response: response}` where I think it should be `{state: undefined, response: response}`.
The program behaves correctly because `result.state` is still undefined.