### PR TITLE
Revert TypeScript changes on state prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -339,7 +339,7 @@ export interface SigninResponse {
   profile: any;
   scope: string;
   session_state: string;
-  state: string;
+  state: any;
   token_type: string;
 
   readonly expired: boolean | undefined;
@@ -354,7 +354,7 @@ export interface SignoutResponse {
   error?: string;
   error_description?: string;
   error_uri?: string;
-  state: string;
+  state?: any;
 }
 
 export interface UserSettings {
@@ -366,7 +366,7 @@ export interface UserSettings {
   scope: string;
   profile: Profile;
   expires_at: number;
-  state: string;
+  state: any;
 }
 
 export class User {
@@ -389,7 +389,7 @@ export class User {
   /** The expires at returned from the OIDC provider */
   expires_at: number;
   /** The custom state transferred in the last signin */
-  state: string;
+  state: any;
 
   toStorageString(): string;
   static fromStorageString(storageString: string): User;


### PR DESCRIPTION
In the PR #964 I made a mistake, when I first read the code I thought that `state` was always a string, but now I realized that later is being overwritten by the parsed state from storage.