### PR TITLE
Do not resolve redirectNavigator.navigate promise

### DIFF
--- a/src/RedirectNavigator.js
+++ b/src/RedirectNavigator.js
@@ -19,10 +19,13 @@ export class RedirectNavigator {
             window.location.replace(params.url);
         }
         else {
-            window.location = params.url;
+            window.location.assign(params.url);
         }
-
-        return Promise.resolve();
+  
+        // The browser keeps executing code after window.location.replace or window.location.assign
+        // are called. We return a promise that never resolves so that code does not keep executing
+        // as this would lead applications into thinking that login has been completed.
+        return new Promise((resolve, reject) => {});
     }
 
     get url() {

--- a/src/UserManager.js
+++ b/src/UserManager.js
@@ -91,9 +91,7 @@ export class UserManager extends OidcClient {
         let navParams = {
             useReplaceToNavigate : args.useReplaceToNavigate
         };
-        return this._signinStart(args, this._redirectNavigator, navParams).then(()=>{
-            Log.info("UserManager.signinRedirect: successful");
-        });
+        return this._signinStart(args, this._redirectNavigator, navParams);
     }
     signinRedirectCallback(url) {
         return this._signinEnd(url || this._redirectNavigator.url).then(user => {


### PR DESCRIPTION
When calling `window.location.replace` or setting `window.location`, code will continue to execute while the browser loads the next page (DNS lookup and/or HTML payload). 

Resolving the promise in `RedirectNavigator` has the (IMO unwanted) effect of making applications think they're logged in when they are not (e.g. by resolving `UserManager.signInRedirect` with `undefined`). 

Because navigation away from the page is imminent (it's not a navigation operation on an iframe), I'm not sure what the value of allowing code to continue to execute in this state is.