### PR TITLE
Fix "Initializers are not allowed in ambient contexts" in TS 2.9

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,11 +38,11 @@ export class InMemoryWebStorage {
 }
 
 export class Log {
-  static readonly NONE = 0;
-  static readonly ERROR = 1;
-  static readonly WARN = 2;
-  static readonly INFO = 3;
-  static readonly DEBUG = 4;
+  static readonly NONE: 0;
+  static readonly ERROR: 1;
+  static readonly WARN: 2;
+  static readonly INFO: 3;
+  static readonly DEBUG: 4;
 
   static reset(): void;
 


### PR DESCRIPTION
Fixes #1015.

Note that current TS versions would allow the initiaizers in declarations.

