### PR TITLE
Add client_secret_basic auth exchangeCode Method. IdentityModel/oidc-client-js#892

### DIFF
--- a/src/JsonService.js
+++ b/src/JsonService.js
@@ -96,7 +96,7 @@ export class JsonService {
         });
     }
 
-    postForm(url, payload) {
+    postForm(url, payload, basicAuth) {
         if (!url){
             Log.error("JsonService.postForm: No url passed");
             throw new Error("url");
@@ -197,6 +197,12 @@ export class JsonService {
             }
 
             req.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+
+            if (basicAuth !== undefined)
+            {
+                req.setRequestHeader("Authorization", "Basic " + btoa(basicAuth));
+            }
+
             req.send(body);
         });
     }

--- a/src/OidcClientSettings.js
+++ b/src/OidcClientSettings.js
@@ -10,6 +10,7 @@ const OidcMetadataUrlPath = '.well-known/openid-configuration';
 
 const DefaultResponseType = "id_token";
 const DefaultScope = "openid";
+const DefaultClientAuthentication = "client_secret_post" // The default value must be client_secret_basic, as explained in https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
 const DefaultStaleStateAge = 60 * 15; // seconds
 const DefaultClockSkewInSeconds = 60 * 5;
 
@@ -20,6 +21,7 @@ export class OidcClientSettings {
         // client related
         client_id, client_secret, response_type = DefaultResponseType, scope = DefaultScope,
         redirect_uri, post_logout_redirect_uri,
+        client_authentication = DefaultClientAuthentication,
         // optional protocol
         prompt, display, max_age, ui_locales, acr_values, resource, response_mode,
         // behavior flags
@@ -46,6 +48,7 @@ export class OidcClientSettings {
         this._scope = scope;
         this._redirect_uri = redirect_uri;
         this._post_logout_redirect_uri = post_logout_redirect_uri;
+        this._client_authentication = client_authentication;
 
         this._prompt = prompt;
         this._display = display;
@@ -98,7 +101,10 @@ export class OidcClientSettings {
     get post_logout_redirect_uri() {
         return this._post_logout_redirect_uri;
     }
-
+    get client_authentication() {
+        return this._client_authentication;
+    }
+    
 
     // optional protocol params
     get prompt() {


### PR DESCRIPTION
See related IdentityModel/oidc-client-js#892

This Pull request add a new parameter named `client_authentication` who hold the needed authentication type (`client_secret_post` or `client_secret_basic`).

To avoid breaking change, the default value is `client_secret_post`.

This PR allow to exchange a *code* for user information in the method `exchangeCode`.