### PR TITLE
feat: merge openid-configuration and metdata

### DIFF
--- a/test/unit/MetadataService.spec.js
+++ b/test/unit/MetadataService.spec.js
@@ -93,24 +93,26 @@ describe("MetadataService", function() {
 
         it("should return metadata from json call", function(done) {
             settings.metadataUrl = "http://sts/metadata";
-            stubJsonService.result = Promise.resolve("test");
+            const expected = { test: "test" };
+            stubJsonService.result = Promise.resolve(expected);
 
             let p = subject.getMetadata();
 
             p.then(result => {
-                result.should.equal("test");
+                result.should.deep.equal(expected);
                 done();
             });
         });
 
         it("should cache metadata from json call", function(done) {
             settings.metadataUrl = "http://sts/metadata";
-            stubJsonService.result = Promise.resolve("test");
+            const expected = { test: "test" };
+            stubJsonService.result = Promise.resolve(expected);
 
             let p = subject.getMetadata();
 
             p.then(result => {
-                settings.metadata.should.equal("test");
+                settings.metadata.should.deep.equal(expected);
                 done();
             });
         });
@@ -123,6 +125,27 @@ describe("MetadataService", function() {
 
             p.then(null, err => {
                 err.message.should.contain("test");
+                done();
+            });
+        });
+
+        it("should return merge openid-configuration  from json call and injected metadata", function(done) {
+            settings.metadataUrl = "http://sts/metadata";
+            settings.metadata = {
+                property1: "injected",
+                property2: "injected"
+            }
+            const response = { property2: "merged" };
+            const expected =  {
+                property1: "injected",
+                property2: "merged"
+            }
+            stubJsonService.result = Promise.resolve(response);
+
+            let p = subject.getMetadata();
+
+            p.then(result => {
+                result.should.deep.equal(expected);
                 done();
             });
         });


### PR DESCRIPTION
Merge the .well-known/openid-configuration over any injected configuration in settings.metadata to allow clients to specify properties missing in their OIDC servers openid-configuration. This is specifically to make life easier with Auth0 or other poorly implemented OIDC servers while waiting on them to get their acts together. 

applies to #1067