### PR TITLE
Properly decode plus character in URLS

### DIFF
--- a/src/UrlUtility.js
+++ b/src/UrlUtility.js
@@ -45,7 +45,7 @@ export class UrlUtility {
 
         var counter = 0;
         while (m = regex.exec(value)) {
-            params[decodeURIComponent(m[1])] = decodeURIComponent(m[2]);
+            params[decodeURIComponent(m[1])] = decodeURIComponent(m[2].replace(/\+/g, ' '));
             if (counter++ > 50) {
                 Log.error("UrlUtility.parseUrlFragment: response exceeded expected number of parameters", value);
                 return {


### PR DESCRIPTION
Currently, the `+` character is not decoded from URL params, since decodeURIComponent cannot do that. MDN [suggests](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent) a solution for that:

> decodeURIComponent cannot be used directly to parse query parameters from a URL. It needs a bit of preparation.