### PR TITLE
Use ErrorResponse to get error_description.  

### DIFF
--- a/src/JsonService.js
+++ b/src/JsonService.js
@@ -3,6 +3,7 @@
 
 import { Log } from './Log.js';
 import { Global } from './Global.js';
+import { ErrorResponse } from "./ErrorResponse.js";
 
 export class JsonService {
     constructor(
@@ -158,7 +159,7 @@ export class JsonService {
                                 var payload = JSON.parse(req.responseText);
                                 if (payload && payload.error) {
                                     Log.error("JsonService.postForm: Error from server: ", payload.error);
-                                    reject(new Error(payload.error));
+                  reject(new ErrorResponse(payload));
                                     return;
                                 }
                             }

--- a/src/JsonService.js
+++ b/src/JsonService.js
@@ -159,7 +159,7 @@ export class JsonService {
                                 var payload = JSON.parse(req.responseText);
                                 if (payload && payload.error) {
                                     Log.error("JsonService.postForm: Error from server: ", payload.error);
-                  reject(new ErrorResponse(payload));
+                                    reject(new ErrorResponse(payload));
                                     return;
                                 }
                             }


### PR DESCRIPTION
error_description will be the default error message due to this change.
Not sure how many users parse this error message and expect it to be 'error' and not 'error_description'.

Should I make a variant of ErrorResponse that will not change old behavior?