### PR TITLE
Remove the dependency on uuid while still supporting window.crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-client",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7460,11 +7460,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
-    },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8flags": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,9 @@
   },
   "homepage": "https://github.com/IdentityModel/oidc-client-js",
   "dependencies": {
-    "uuid": "^3.3.2",
+    "base64-js": "^1.3.0",
     "core-js": "^2.6.4",
-    "crypto-js": "^3.1.9-1",
-    "base64-js": "^1.3.0"
+    "crypto-js": "^3.1.9-1"
   },
   "devDependencies": {
     "babel-core": "^6.7.2",

--- a/src/random.js
+++ b/src/random.js
@@ -1,9 +1,25 @@
-import uuid4 from 'uuid/v4';
 
 /**
  * Generates RFC4122 version 4 guid ()
  */
 
+var crypto = (typeof window !== 'undefined') ? (window.crypto || window.msCrypto) : null;
+
+function _cryptoUuidv4() {
+  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  )
+}
+
+function _uuidv4() {
+    return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+    (c ^ Math.random() * 16 >> c / 4).toString(16)
+  )
+}
+
 export default function random() {
-  return uuid4().replace(/-/g, '');
+  var hasCrypto = crypto != 'undefined' && crypto !== null;
+  var hasRandomValues = hasCrypto && (typeof(crypto.getRandomValues) != 'undefined');  
+  var uuid = hasRandomValues ? _cryptoUuidv4 : _uuidv4;
+  return uuid().replace(/-/g, '');
 }


### PR DESCRIPTION
Relates to the following 2 pull requests https://github.com/IdentityModel/oidc-client-js/pull/848 https://github.com/IdentityModel/oidc-client-js/pull/769

For my use case, I am creating es6 web components and using rollup to bundle them as es to be included as a script on a webpage. One of the components selectively imports oidc-client modules to be included in the bundle, so I only import what I need. I have karma-esm running tests on my code without bundling in the browser.

Here are the problems I have with the uuid dependency. One was that rollup would not bundle the oidc-client code due to random.js using `import uuid4 from 'uuid/v4`. I would get the error `'default' is not exported by node_modules/uuid/v4.js` presumably due to mixing es import with `module.exports = ` If I changed the line back to `const uuid = require('uuid/v4')` I could then create a bundle, but then my own tests would fail due to not understanding 'require' in the browser as this code would be imported.

I did try using @rollup/plugin-commonjs but this just caused different problems, I would get unresolved external errors instead. I also tried taking the oidc-client.min.js built code and including this on my webpages but this also caused me headaches in testing with components needing to import or require to deal with the Oidc variable. 

So this solution is by far the easiest for me, it has the benefit of reducing dependencies for oidc-client and you can minimize the included code while still using crypto. The oidc-tests pass so it still creates the uuid with the correct pattern.

I know there are many ways to create uuid4 (see https://stackoverflow.com/questions/105034/how-to-create-guid-uuid/43901924) and you may want to revert to the previous version of random.js using Math.random, it doesn't matter the implementation to me as long as there is no dependency on uuid package. 

Do you think it worth merging in some form?

