### PR TITLE
Include nonce in Authorization Code flow

### DIFF
--- a/src/SigninState.js
+++ b/src/SigninState.js
@@ -7,7 +7,7 @@ import { JoseUtil } from './JoseUtil.js';
 import random from './random.js';
 
 export class SigninState extends State {
-    constructor({nonce, authority, client_id, redirect_uri, code_verifier, response_mode, client_secret, scope, extraTokenParams, skipUserInfo} = {}) {
+    constructor({nonce, authority, client_id, redirect_uri, response_type, code_verifier, response_mode, client_secret, scope, extraTokenParams, skipUserInfo} = {}) {
         super(arguments[0]);
 
         if (nonce === true) {
@@ -24,7 +24,7 @@ export class SigninState extends State {
         else if (code_verifier) {
             this._code_verifier = code_verifier;
         }
-        
+
         if (this.code_verifier) {
             let hash = JoseUtil.hashString(this.code_verifier, "SHA256");
             this._code_challenge = JoseUtil.hexToBase64Url(hash);
@@ -33,6 +33,7 @@ export class SigninState extends State {
         this._redirect_uri = redirect_uri;
         this._authority = authority;
         this._client_id = client_id;
+        this._response_type = response_type;
         this._response_mode = response_mode;
         this._client_secret = client_secret;
         this._scope = scope;
@@ -51,6 +52,9 @@ export class SigninState extends State {
     }
     get redirect_uri() {
         return this._redirect_uri;
+    }
+    get response_type() {
+        return this._response_type;
     }
     get code_verifier() {
         return this._code_verifier;
@@ -73,7 +77,7 @@ export class SigninState extends State {
     get skipUserInfo() {
         return this._skipUserInfo;
     }
-    
+
     toStorageString() {
         Log.debug("SigninState.toStorageString");
         return JSON.stringify({
@@ -82,6 +86,7 @@ export class SigninState extends State {
             created: this.created,
             request_type: this.request_type,
             nonce: this.nonce,
+            response_type: this.response_type,
             code_verifier: this.code_verifier,
             redirect_uri: this.redirect_uri,
             authority: this.authority,

--- a/test/unit/ResponseValidator.spec.js
+++ b/test/unit/ResponseValidator.spec.js
@@ -135,7 +135,8 @@ describe("ResponseValidator", function () {
             nonce: "7221005209972382",
             data: { some: 'data' },
             client_id: "client",
-            authority: "op"
+            authority: "op",
+            response_type: "id_token"
         };
         stubResponse = {
             state: 'the_id',
@@ -387,7 +388,7 @@ describe("ResponseValidator", function () {
 
         it("should fail if request was not OIDC but id_token in response", function (done) {
 
-            delete stubState.nonce;
+            stubState.response_type = 'code';
             stubResponse.id_token = id_token;
 
             subject._processSigninParams(stubState, stubResponse).then(null, err => {
@@ -409,7 +410,7 @@ describe("ResponseValidator", function () {
             });
 
         });
-        
+
         it("should fail if request was not code flow no code in response", function (done) {
 
             stubResponse.id_token = id_token;

--- a/test/unit/SigninRequest.spec.js
+++ b/test/unit/SigninRequest.spec.js
@@ -218,13 +218,30 @@ describe("SigninRequest", function() {
             subject.url.should.contain("code_challenge=");
             subject.url.should.contain("code_challenge_method=S256");
         });
-        
+
         it("should include hybrid flow params", function() {
             settings.response_type = "code id_token";
             subject = new SigninRequest(settings);
             subject.url.should.contain("nonce=");
             subject.url.should.contain("code_challenge=");
             subject.url.should.contain("code_challenge_method=S256");
+        });
+
+        it("should include nonce", function() {
+            subject.url.should.contain("nonce=");
+        });
+
+        it("should include for code flow if opend in scope", function() {
+            settings.response_type = "code";
+            subject = new SigninRequest(settings);
+            subject.url.should.contain("nonce=");
+        });
+
+        it("should not include nonce for none oidc flow", function() {
+            settings.scope = "foobar";
+            settings.response_type = "code";
+            subject = new SigninRequest(settings);
+            subject.url.should.not.contain("nonce=");
         });
     });
 


### PR DESCRIPTION
This PR aims to support `nonce` in Authorization Code flow. 

This library does not support hybrid flow. On the other hand, it only includes `nonce` if the response_type if `id_token`. There is no way to generate a `nonce` when an application needs to acquire access_token from the OIDC server.

Checking if `openid` appears in `scope` value seems to be the minimal modification to support this feature.