### PR TITLE
Fix UserManager.signoutCallback typing

### DIFF
--- a/dist/oidc-client.d.ts
+++ b/dist/oidc-client.d.ts
@@ -208,7 +208,7 @@ export class UserManager extends OidcClient {
   signinCallback(url?: string): Promise<User>;
 
   /** Proxy to Popup and Redirect callbacks */
-  signoutCallback(url?: string, keepWindowOpen?: boolean): Promise<SignoutResponse | void>;
+  signoutCallback(url?: string, keepWindowOpen?: boolean): Promise<SignoutResponse | undefined>;
 
   /** Query OP for user's current signin status */
   querySessionStatus(args?: any): Promise<SessionStatus>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -208,7 +208,7 @@ export class UserManager extends OidcClient {
   signinCallback(url?: string): Promise<User>;
 
   /** Proxy to Popup and Redirect callbacks */
-  signoutCallback(url?: string, keepWindowOpen?: boolean): Promise<SignoutResponse | void>;
+  signoutCallback(url?: string, keepWindowOpen?: boolean): Promise<SignoutResponse | undefined>;
 
   /** Query OP for user's current signin status */
   querySessionStatus(args?: any): Promise<SessionStatus>;


### PR DESCRIPTION
The typing for `UserManager.signoutCallback` currently makes this method return `SignoutResponse | void`.

Although legal, variables should not be of type `void`, from the [typescript specifications](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#325-the-void-type):

> NOTE: We might consider disallowing declaring variables of type Void as they serve no useful purpose. However, because Void is permitted as a type argument to a generic type or function it is not feasible to disallow Void properties or parameters.

Additionally, attempting to use a variable of type `SignoutResponse | void` won't let us treat it as `null` or `undefined` like in the next example:

```typescript
const response: SignoutResponse | void = await userManager.signoutCallback(window.location.href);
doSomething(response?.state?.someStateItem);
// This lints 'state' with : TS2339 (TS) Property 'state' does not exist on type 'void | SignoutResponse'.
```

Using `undefined` or `null` for `UserManager.signoutCallback` works for the above example and is semantically correct because there is a chance `SignoutResponse` or nothing is returned (`undefined`).

Using `void` here is not semantically correct because `UserManager.signoutCallback` **can** return something, even if that something is `undefined`.
Also, using `void` forces developers to hack around `userManager.signoutCallback`'s return type in order to use strict typing.