### PR TITLE
Render invisible iframes for silentRenew on Firefox

### DIFF
--- a/src/IFrameWindow.js
+++ b/src/IFrameWindow.js
@@ -21,7 +21,6 @@ export class IFrameWindow {
         // shotgun approach
         this._frame.style.visibility = "hidden";
         this._frame.style.position = "absolute";
-        this._frame.style.display = "none";
         this._frame.style.width = 0;
         this._frame.style.height = 0;
 


### PR DESCRIPTION
Firefox has an issue where certain things in hidden iframes are not rendered. This results in a "Frame window timed out"-error on `signinSilent`.
Removing the `display: none`; while keeping the other css-rules should ensure that it is not visible and too small to be clicked, while the iframe will still be able to be rendered and complete the sign in.

https://stackoverflow.com/questions/2730046/javascript-problem-with-iframe-thats-hidden-before-loaded/2786429#2786429
Perhaps the [related issue at Mozilla here](https://bugzilla.mozilla.org/show_bug.cgi?id=548397).