### PR TITLE
add optional refresh_token to SigninResponse

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -331,6 +331,9 @@ export interface SigninResponse {
   new (url: string, delimiter?: string): SigninResponse;
 
   access_token: string;
+  /** Refresh token returned from the OIDC provider (if requested, via the
+   * 'offline_access' scope) */
+  refresh_token?: string;
   code: string;
   error: string;
   error_description: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-client",
-  "version": "1.11.0-beta.1",
+  "version": "1.11.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Simply adds the optional refresh_token to the SigninResponse type interface (allowing developers to extract this token without having to coerce TypeScript).