### PR TITLE
Keep existing id_token if not in token result

### DIFF
--- a/src/UserManager.js
+++ b/src/UserManager.js
@@ -198,7 +198,7 @@ export class UserManager extends OidcClient {
 
                     return idTokenValidation.then(() => {
                         Log.debug("UserManager._useRefreshToken: refresh token response success");
-                        user.id_token = result.id_token;
+                        user.id_token = result.id_token || user.id_token;
                         user.access_token = result.access_token;
                         user.refresh_token = result.refresh_token || user.refresh_token;
                         user.expires_in = result.expires_in;


### PR DESCRIPTION
Returning an ID token from requests to the token endpoint using the
`refresh_token` grant is optional. Thus also applying the ID token to
the user data structure must be optional if no new `id_token` value is
returned. This change implements just that in a very similiar way as how
the existing `refresh_token` value is kept.

Fixes: #1236