### PR TITLE
fix: remove getEpochTime from OidcClientSettings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -166,8 +166,6 @@ export interface OidcClientSettings {
   MetadataServiceCtor?: MetadataServiceCtor;
   /** An object containing additional query string parameters to be including in the authorization request */
   extraQueryParams?: Record<string, any>;
-
-  getEpochTime(): Promise<number>;
 }
 
 export class UserManager extends OidcClient {


### PR DESCRIPTION
OidcClientSettings (in OidcClientSettings.js) doesn't appear to accept
that in its constructor.

This should also address https://github.com/IdentityModel/oidc-client-js/pull/1271#issuecomment-769877657