### PR TITLE
feat(MetadataService): add metadata_override

### DIFF
--- a/src/MetadataService.js
+++ b/src/MetadataService.js
@@ -60,7 +60,8 @@ export class MetadataService {
                 Log.debug("MetadataService.getMetadata: json received");
                 
                 var seed = this._settings.metadataSeed || {};
-                this._settings.metadata = Object.assign({}, seed, metadata);
+                var override = this._settings.metadataOverride || {};
+                this._settings.metadata = Object.assign({}, seed, metadata, override);
                 return this._settings.metadata;
             });
     }

--- a/src/OidcClientSettings.js
+++ b/src/OidcClientSettings.js
@@ -18,7 +18,7 @@ const DefaultClockSkewInSeconds = 60 * 5;
 export class OidcClientSettings {
     constructor({
         // metadata related
-        authority, metadataUrl, metadata, signingKeys, metadataSeed,
+        authority, metadataUrl, metadata, metadataOverride, signingKeys, metadataSeed,
         // client related
         client_id, client_secret, response_type = DefaultResponseType, scope = DefaultScope,
         redirect_uri, post_logout_redirect_uri,
@@ -45,6 +45,7 @@ export class OidcClientSettings {
         this._metadataUrl = metadataUrl;
         this._metadata = metadata;
         this._metadataSeed = metadataSeed;
+        this._metadataOverride = metadataOverride;
         this._signingKeys = signingKeys;
 
         this._client_id = client_id;
@@ -178,6 +179,13 @@ export class OidcClientSettings {
     }
     set metadataSeed(value) {
         this._metadataSeed = value;
+    }
+
+    get metadataOverride() {
+        return this._metadataOverride;
+    }
+    set metadataOverride(value) {
+        this._metadataOverride = value;
     }
 
     get signingKeys() {

--- a/test/unit/MetadataService.spec.js
+++ b/test/unit/MetadataService.spec.js
@@ -93,12 +93,12 @@ describe("MetadataService", function() {
 
         it("should return metadata from json call", function(done) {
             settings.metadataUrl = "http://sts/metadata";
-            stubJsonService.result = Promise.resolve("test");
+            stubJsonService.result = Promise.resolve({test: "test"});
 
             let p = subject.getMetadata();
 
             p.then(result => {
-                result.should.equal("test");
+                result.should.deep.equal({test: "test"});
                 done();
             });
         });
@@ -118,7 +118,7 @@ describe("MetadataService", function() {
         it.only("should merge metadata from seed", function(done) {
             settings.metadataUrl = "http://sts/metadata";
             settings.metadataSeed = {test1:"one"};
-            stubJsonService.result = Promise.resolve({test2:"two"});
+            stubJsonService.result = Promise.resolve({test1: "two", test2:"two"});
 
             let p = subject.getMetadata();
 
@@ -137,6 +137,29 @@ describe("MetadataService", function() {
 
             p.then(null, err => {
                 err.message.should.contain("test");
+                done();
+            });
+        });
+
+        it("should openid-configuration be overridable", function(done) {
+            settings.metadataUrl = "http://sts/metadata";
+            settings.metadataOverride = {
+                property2: "overrided",
+            }
+            const response = {
+                property1: "original1",
+                property2: "original2"
+            }
+            const expected =  {
+                property1: "original1",
+                property2: "overrided"
+            }
+            stubJsonService.result = Promise.resolve(response);
+
+            let p = subject.getMetadata();
+
+            p.then(result => {
+                result.should.deep.equal(expected);
                 done();
             });
         });


### PR DESCRIPTION
The OpenID providers describes configuration exactly as is. But sometimes it is requires to be override. From #1068 customisation of providers options is no more available. This solution is save #1068 behaviour and adds ability to override metadata of OpenID configuration.

So if `token_endpoint` need to be overrided it is may be done like this:

```js
  const userManager = new UserManager({
    authority: issuer,
    ...
    //metadata,
    metadataOverride: {
      token_endpoint: tokenUrl,
    },
  })
```