### PR TITLE
feat: add support `access_type` param

### DIFF
--- a/src/OidcClient.js
+++ b/src/OidcClient.js
@@ -44,7 +44,8 @@ export class OidcClient {
         // have round tripped, but people were getting confused, so i added state (since that matches the spec)
         // and so now if data is not passed, but state is then state will be used
         data, state, prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values,
-        resource, request, request_uri, response_mode, extraQueryParams, extraTokenParams, request_type, skipUserInfo } = {},
+        resource, request, request_uri, response_mode, extraQueryParams, extraTokenParams, request_type,
+        skipUserInfo, access_type } = {},
         stateStore
     ) {
         Log.debug("OidcClient.createSigninRequest");
@@ -56,6 +57,7 @@ export class OidcClient {
 
         // id_token_hint, login_hint aren't allowed on _settings
         prompt = prompt || this._settings.prompt;
+        access_type = access_type || this._settings.access_type;
         display = display || this._settings.display;
         max_age = max_age || this._settings.max_age;
         ui_locales = ui_locales || this._settings.ui_locales;
@@ -82,7 +84,7 @@ export class OidcClient {
                 scope,
                 data: data || state,
                 authority,
-                prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values,
+                prompt, access_type, display, max_age, ui_locales, id_token_hint, login_hint, acr_values,
                 resource, request, request_uri, extraQueryParams, extraTokenParams, request_type, response_mode,
                 client_secret: this._settings.client_secret,
                 skipUserInfo

--- a/src/SigninRequest.js
+++ b/src/SigninRequest.js
@@ -11,7 +11,8 @@ export class SigninRequest {
         url, client_id, redirect_uri, response_type, scope, authority,
         // optional
         data, prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values, resource, response_mode,
-        request, request_uri, extraQueryParams, request_type, client_secret, extraTokenParams, skipUserInfo
+        request, request_uri, extraQueryParams, request_type, client_secret, extraTokenParams, skipUserInfo,
+        access_type,
     }) {
         if (!url) {
             Log.error("SigninRequest.ctor: No url passed");
@@ -65,7 +66,10 @@ export class SigninRequest {
             url = UrlUtility.addQueryParam(url, "code_challenge_method", "S256");
         }
 
-        var optional = { prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values, resource, request, request_uri, response_mode };
+        var optional = {
+            prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values,
+            resource, request, request_uri, response_mode, access_type,
+        };
         for(let key in optional){
             if (optional[key]) {
                 url = UrlUtility.addQueryParam(url, key, optional[key]);


### PR DESCRIPTION
Some providers does not return `refresh_token` without a couple of params:

```js
{
  prompt: 'consent',
  access_type: 'offline',
}
```

refs:

* [Not receiving Google OAuth refresh token](https://stackoverflow.com/questions/10827920/not-receiving-google-oauth-refresh-token/10857806#10857806)
* [Using OAuth 2.0 for Web Server Applications](https://developers.google.com/identity/protocols/oauth2/web-server)

This adds support of `access_type` param which currently is not supported yet. 