### PR TITLE
Feat: Option to send credentials with http requests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -162,6 +162,8 @@ export interface OidcClientSettings {
   readonly stateStore?: StateStore;
   readonly userInfoJwtIssuer?: 'ANY' | 'OP' | string;
   readonly mergeClaims?: boolean;
+  /** sets XMLHTTPRequest.withCredentials value for requests */
+  readonly sendRequestsWithCredentials?: boolean;
   ResponseValidatorCtor?: ResponseValidatorCtor;
   MetadataServiceCtor?: MetadataServiceCtor;
   /** An object containing additional query string parameters to be including in the authorization request */

--- a/src/JsonService.js
+++ b/src/JsonService.js
@@ -8,8 +8,12 @@ export class JsonService {
     constructor(
         additionalContentTypes = null, 
         XMLHttpRequestCtor = Global.XMLHttpRequest, 
-        jwtHandler = null
+        jwtHandler = null,
+        settings,
     ) {
+
+        this._settings = settings;
+
         if (additionalContentTypes && Array.isArray(additionalContentTypes))
         {
             this._contentTypes = additionalContentTypes.slice();
@@ -39,6 +43,10 @@ export class JsonService {
 
             var req = new this._XMLHttpRequest();
             req.open('GET', url);
+
+            if(this._settings && this._settings.sendRequestsWithCredentials){
+                req.withCredentials = true;
+            }
 
             var allowedContentTypes = this._contentTypes;
             var jwtHandler = this._jwtHandler;
@@ -108,6 +116,10 @@ export class JsonService {
 
             var req = new this._XMLHttpRequest();
             req.open('POST', url);
+
+            if(this._settings && this._settings.sendRequestsWithCredentials){
+                req.withCredentials = true;
+            }
 
             var allowedContentTypes = this._contentTypes;
 

--- a/src/MetadataService.js
+++ b/src/MetadataService.js
@@ -14,7 +14,7 @@ export class MetadataService {
         }
 
         this._settings = settings;
-        this._jsonService = new JsonServiceCtor(['application/jwk-set+json']);
+        this._jsonService = new JsonServiceCtor(['application/jwk-set+json'], undefined, undefined, this._settings);
     }
 
     get metadataUrl() {

--- a/src/OidcClientSettings.js
+++ b/src/OidcClientSettings.js
@@ -32,6 +32,7 @@ export class OidcClientSettings {
         clockService = new ClockService(),
         userInfoJwtIssuer = 'OP',
         mergeClaims = false,
+        sendRequestsWithCredentials = false,
         // other behavior
         stateStore = new WebStorageStateStore(),
         ResponseValidatorCtor = ResponseValidator,
@@ -74,6 +75,8 @@ export class OidcClientSettings {
         this._stateStore = stateStore;
         this._validator = new ResponseValidatorCtor(this);
         this._metadataService = new MetadataServiceCtor(this);
+
+        this._sendRequestsWithCredentials = sendRequestsWithCredentials;
 
         this._extraQueryParams = typeof extraQueryParams === 'object' ? extraQueryParams : {};
         this._extraTokenParams = typeof extraTokenParams === 'object' ? extraTokenParams : {};
@@ -215,6 +218,9 @@ export class OidcClientSettings {
     }
     get metadataService() {
         return this._metadataService;
+    }
+   get sendRequestsWithCredentials() {
+        return this._sendRequestsWithCredentials;
     }
 
     // extra query params

--- a/src/TokenClient.js
+++ b/src/TokenClient.js
@@ -13,7 +13,7 @@ export class TokenClient {
         }
 
         this._settings = settings;
-        this._jsonService = new JsonServiceCtor();
+        this._jsonService = new JsonServiceCtor(undefined, undefined, undefined, this._settings);
         this._metadataService = new MetadataServiceCtor(this._settings);
     }
 

--- a/src/UserInfoService.js
+++ b/src/UserInfoService.js
@@ -19,7 +19,7 @@ export class UserInfoService {
         }
 
         this._settings = settings;
-        this._jsonService = new JsonServiceCtor(undefined, undefined, this._getClaimsFromJwt.bind(this));
+        this._jsonService = new JsonServiceCtor(undefined, undefined, this._getClaimsFromJwt.bind(this), this._settings);
         this._metadataService = new MetadataServiceCtor(this._settings);
         this._joseUtil = joseUtil;
     }


### PR DESCRIPTION
Fixes #1062 

This PR implements the ability to set the ```withCredentials``` value for HTTP requests via a configuration option.
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials

This is important as it is often necessary to set this value to ```true``` if a token request also returns cookies. Providing refresh tokens as secure cookies is considered by many to be a best-practice.
https://hasura.io/blog/best-practices-of-using-jwt-with-graphql/