### PR TITLE
Use fetch instead of XMLHttpRequest

### DIFF
--- a/src/UserInfoService.js
+++ b/src/UserInfoService.js
@@ -19,7 +19,7 @@ export class UserInfoService {
         }
 
         this._settings = settings;
-        this._jsonService = new JsonServiceCtor(undefined, undefined, this._getClaimsFromJwt.bind(this));
+        this._jsonService = new JsonServiceCtor(undefined, this._getClaimsFromJwt.bind(this));
         this._metadataService = new MetadataServiceCtor(this._settings);
         this._joseUtil = joseUtil;
     }
@@ -40,9 +40,9 @@ export class UserInfoService {
         });
     }
 
-    _getClaimsFromJwt(req) {
+    _getClaimsFromJwt(responseText) {
         try {
-            let jwt = this._joseUtil.parseJwt(req.responseText);
+            let jwt = this._joseUtil.parseJwt(responseText);
             if (!jwt || !jwt.header || !jwt.payload) {
                 Log.error("UserInfoService._getClaimsFromJwt: Failed to parse JWT", jwt);
                 return Promise.reject(new Error("Failed to parse id_token"));
@@ -103,7 +103,7 @@ export class UserInfoService {
                     let clockSkewInSeconds = this._settings.clockSkew;
                     Log.debug("UserInfoService._getClaimsFromJwt: Validaing JWT; using clock skew (in seconds) of: ", clockSkewInSeconds);
 
-                    return this._joseUtil.validateJwt(req.responseText, key, issuer, audience, clockSkewInSeconds, undefined, true).then(() => {
+                    return this._joseUtil.validateJwt(responseText, key, issuer, audience, clockSkewInSeconds, undefined, true).then(() => {
                         Log.debug("UserInfoService._getClaimsFromJwt: JWT validation successful");
                         return jwt.payload;
                     });


### PR DESCRIPTION
XMLHttpRequest is not available inside service workers. One can always polyfill fetch onto XMLHttpRequest (there are many available) but I could not find any working polyfill for the opposite (polyfill XMLHttpRequest using fetch).

Also, I tried to use `Oidc.Global.setXMLHttpRequest` but I didn't really work, `window` is not defined so it is not returning set `request`, even when set. I think that check should be removed, or at least wrapped around `|| XMLHttpRequest` check only.

TODO:
* What to do about `Oidc.Global.setXMLHttpRequest` and `get XMLHttpRequest`? Should I change them to be about `fetch`?

See also: https://github.com/IdentityModel/oidc-client-js/issues/1336