### PR TITLE
Attach extra token response claims as property on user object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -406,8 +406,8 @@ export class User {
   expires_at: number;
   /** The custom state transferred in the last signin */
   state: any;
-  /** Other claims sent in the token response */
-  otherClaims: Record<string, any>;
+  /** Other values sent in the token response */
+  otherValues: Record<string, any>;
 
   toStorageString(): string;
   static fromStorageString(storageString: string): User;

--- a/index.d.ts
+++ b/index.d.ts
@@ -406,6 +406,8 @@ export class User {
   expires_at: number;
   /** The custom state transferred in the last signin */
   state: any;
+  /** Other claims sent in the token response */
+  otherClaims: Record<string, any>;
 
   toStorageString(): string;
   static fromStorageString(storageString: string): User;

--- a/src/ResponseValidator.js
+++ b/src/ResponseValidator.js
@@ -259,8 +259,10 @@ export class ResponseValidator {
         
         return this._tokenClient.exchangeCode(request).then(tokenResponse => {
             
-            for(var key in tokenResponse) {
-                response[key] = tokenResponse[key];
+            for (var key in tokenResponse) {
+                if (Object.prototype.hasOwnProperty.call(tokenResponse, key)) {
+                    response[key] = tokenResponse[key];
+                }
             }
 
             if (response.id_token) {

--- a/src/SigninResponse.js
+++ b/src/SigninResponse.js
@@ -10,20 +10,12 @@ export class SigninResponse {
 
         var values = UrlUtility.parseUrlFragment(url, delimiter);
 
-        this.error = values.error;
-        this.error_description = values.error_description;
-        this.error_uri = values.error_uri;
-
-        this.code = values.code;
-        this.state = values.state;
-        this.id_token = values.id_token;
-        this.session_state = values.session_state;
-        this.access_token = values.access_token;
-        this.token_type = values.token_type;
-        this.scope = values.scope;
+        for (var key in values) {
+            if (Object.prototype.hasOwnProperty.call(values, key)) {
+                this[key] = values[key];
+            }
+        }
         this.profile = undefined; // will be set from ResponseValidator
-
-        this.expires_in = values.expires_in;
     }
 
     get expires_in() {

--- a/src/User.js
+++ b/src/User.js
@@ -4,7 +4,7 @@
 import { Log } from './Log.js';
 
 export class User {
-    constructor({id_token, session_state, access_token, refresh_token, token_type, scope, profile, expires_at, state, ...otherClaims}) {
+    constructor({id_token, session_state, access_token, refresh_token, token_type, scope, profile, expires_at, state, ...otherValues}) {
         this.id_token = id_token;
         this.session_state = session_state;
         this.access_token = access_token;
@@ -14,7 +14,7 @@ export class User {
         this.profile = profile;
         this.expires_at = expires_at;
         this.state = state;
-        this.otherClaims = otherClaims;
+        this.otherValues = otherValues;
     }
 
     get expires_in() {

--- a/src/User.js
+++ b/src/User.js
@@ -4,7 +4,7 @@
 import { Log } from './Log.js';
 
 export class User {
-    constructor({id_token, session_state, access_token, refresh_token, token_type, scope, profile, expires_at, state}) {
+    constructor({id_token, session_state, access_token, refresh_token, token_type, scope, profile, expires_at, state, ...otherClaims}) {
         this.id_token = id_token;
         this.session_state = session_state;
         this.access_token = access_token;
@@ -14,6 +14,7 @@ export class User {
         this.profile = profile;
         this.expires_at = expires_at;
         this.state = state;
+        this.otherClaims = otherClaims;
     }
 
     get expires_in() {
@@ -53,7 +54,8 @@ export class User {
             token_type: this.token_type,
             scope: this.scope,
             profile: this.profile,
-            expires_at: this.expires_at
+            expires_at: this.expires_at,
+            ...this.otherClaims
         });
     }
 


### PR DESCRIPTION
Hi, thanks for the amazing work on this library. I'm hoping this change can make it in quickly!

I'm using this library against a service implementing the SMART on FHIR OAuth extension. Upon signin, the token response has a few extra parameters that are passed to this library's `User` constructor, but they aren't stored anywhere. I've looked closely and there doesn't seem to be a good way to read these properties short of reimplementing most of `UserManager`. As such I've modified the constructor to store these additional fields as `otherClaims`.