### PR TITLE
set the missing style 'display: none;' on the iframe

### DIFF
--- a/src/IFrameWindow.js
+++ b/src/IFrameWindow.js
@@ -19,6 +19,7 @@ export class IFrameWindow {
         this._frame = window.document.createElement("iframe");
 
         // shotgun approach
+        this._frame.style.display = "none";
         this._frame.style.visibility = "hidden";
         this._frame.style.position = "absolute";
         this._frame.width = 0;


### PR DESCRIPTION
This PR addresses issue #1357 

added the missing style 'display: none;' when iframes are created using IFrameWindow class.
This makes sure that the generated iframe does not interfere with client html and css.